### PR TITLE
Report physical blocks used

### DIFF
--- a/goofys.go
+++ b/goofys.go
@@ -135,6 +135,8 @@ func NewGoofys(bucket string, awsConfig *aws.Config, uid uint32, gid uint32) *Go
 		Crtime: now,
 		Uid:  uid,
 		Gid:  gid,
+		Blocks: 8,
+		BlockSize: 512,
 	}
 
 	fs.bufferPool = NewBufferPool(100 * 1024 * 1024, 20 * 1024 * 1024)
@@ -325,6 +327,8 @@ func (fs *Goofys) LookUpInodeMaybeDir(name *string, fullName *string) (inode *In
 				Crtime: *resp.LastModified,
 				Uid:  fs.uid,
 				Gid:  fs.gid,
+				Blocks: uint64(*resp.ContentLength + 512 - 1) / ^uint64(512 - 1),
+				BlockSize: 512,
 			}
 			return
 		case err = <- errObjectChan:

--- a/handles.go
+++ b/handles.go
@@ -208,6 +208,8 @@ func (parent *Inode) Create(
 		Crtime: now,
 		Uid:  fs.uid,
 		Gid:  fs.gid,
+		Blocks: 0,
+		BlockSize: 512,
 	}
 
 	fh = NewFileHandle(inode)
@@ -606,6 +608,8 @@ func (dh *DirHandle) ReadDir(fs *Goofys, offset fuseops.DirOffset) (*fuseutil.Di
 				Crtime: *obj.LastModified,
 				Uid:  fs.uid,
 				Gid:  fs.gid,
+				Blocks: (uint64(*obj.Size) + 512 - 1) / ^uint64(512 - 1),
+				BlockSize: 512,
 			}
 		}
 


### PR DESCRIPTION
goofys does not support sparse files so always report the object size
for files.