### PR TITLE
Add support for AWS profiles

### DIFF
--- a/internal/flags.go
+++ b/internal/flags.go
@@ -122,6 +122,11 @@ func NewApp() (app *cli.App) {
 					" (deprecated, always on)",
 			},
 
+			cli.StringFlag{
+				Name:  "profile",
+				Usage: "Use a named profile from $HOME/.aws/credentials instead of \"default\"",
+			},
+
 			/////////////////////////
 			// Tuning
 			/////////////////////////
@@ -175,6 +180,7 @@ type FlagStorage struct {
 	Endpoint       string
 	StorageClass   string
 	UsePathRequest bool
+	Profile        string
 
 	// Tuning
 	StatCacheTTL time.Duration
@@ -228,6 +234,7 @@ func PopulateFlags(c *cli.Context) (flags *FlagStorage) {
 		Endpoint:       c.String("endpoint"),
 		StorageClass:   c.String("storage-class"),
 		UsePathRequest: c.Bool("use-path-request"),
+		Profile:        c.String("profile"),
 
 		// Debugging,
 		DebugFuse:  c.Bool("debug_fuse"),

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 
 	"github.com/codegangsta/cli"
 
@@ -72,9 +73,15 @@ func mount(
 	mountPoint string,
 	flags *FlagStorage) (mfs *fuse.MountedFileSystem, err error) {
 
+	var creds *credentials.Credentials
+	if len(flags.Profile) > 0 {
+		creds = credentials.NewSharedCredentials(os.Getenv("HOME")+"/.aws/credentials", flags.Profile)
+	}
+
 	awsConfig := &aws.Config{
-		Region: aws.String("us-west-2"),
-		Logger: GetLogger("s3"),
+		Region:      aws.String("us-west-2"),
+		Logger:      GetLogger("s3"),
+		Credentials: creds,
 		//LogLevel: aws.LogLevel(aws.LogDebug),
 	}
 	if len(flags.Endpoint) > 0 {


### PR DESCRIPTION
`$HOME/.aws/credentials` supports multiple profiles via Windows
INI-style stanzas.