### PR TITLE
restoring default credentials object

### DIFF
--- a/main.go
+++ b/main.go
@@ -73,17 +73,16 @@ func mount(
 	mountPoint string,
 	flags *FlagStorage) (mfs *fuse.MountedFileSystem, err error) {
 
-	var creds *credentials.Credentials
-	if len(flags.Profile) > 0 {
-		creds = credentials.NewSharedCredentials(os.Getenv("HOME")+"/.aws/credentials", flags.Profile)
-	}
-
 	awsConfig := &aws.Config{
 		Region:      &flags.Region,
 		Logger:      GetLogger("s3"),
-		Credentials: creds,
 		//LogLevel: aws.LogLevel(aws.LogDebug),
 	}
+
+	if len(flags.Profile) > 0 {
+		awsConfig.Credentials = credentials.NewSharedCredentials(os.Getenv("HOME")+"/.aws/credentials", flags.Profile)
+	}
+
 	if len(flags.Endpoint) > 0 {
 		awsConfig.Endpoint = &flags.Endpoint
 	}


### PR DESCRIPTION
Fix for #84

Restoring default credentials object to "a chain of credential providers to search for credentials in environment variables, shared credential file, and EC2 Instance Roles" 

http://docs.aws.amazon.com/sdk-for-go/api/aws/Config.html#Credentials-field

Previously, the "Credentials" field was left nil if there was no "--profile" argument. Now the Credentials field will be left at the default.