### PR TITLE
Add a --credentials option and respect AWS environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,33 @@
+# Editor files
 *~
+*.swp
+
+# Binaries
 goofys
-goofys.test
 xout
 s3proxy.jar
+
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -132,8 +132,13 @@ func NewApp() (app *cli.App) {
 			},
 
 			cli.StringFlag{
+				Name:  "credentials",
+				Usage: "Use a custom credentials file instead of \"$HOME/.aws/credentials\"",
+			},
+
+			cli.StringFlag{
 				Name:  "profile",
-				Usage: "Use a named profile from $HOME/.aws/credentials instead of \"default\"",
+				Usage: "Use a named profile from the credentials file instead of \"default\"",
 			},
 
 			cli.BoolFlag{
@@ -191,12 +196,13 @@ type FlagStorage struct {
 	Gid          uint32
 
 	// S3
-	Endpoint       string
-	Region         string
-	StorageClass   string
-	UsePathRequest bool
-	Profile        string
-	UseContentType bool
+	Endpoint        string
+	Region          string
+	StorageClass    string
+	UsePathRequest  bool
+	CredentialsPath string
+	Profile         string
+	UseContentType  bool
 
 	// Tuning
 	StatCacheTTL time.Duration
@@ -247,12 +253,13 @@ func PopulateFlags(c *cli.Context) (flags *FlagStorage) {
 		TypeCacheTTL: c.Duration("type-cache-ttl"),
 
 		// S3
-		Endpoint:       c.String("endpoint"),
-		Region:         c.String("region"),
-		StorageClass:   c.String("storage-class"),
-		UsePathRequest: c.Bool("use-path-request"),
-		Profile:        c.String("profile"),
-		UseContentType: c.Bool("use-content-type"),
+		Endpoint:        c.String("endpoint"),
+		Region:          c.String("region"),
+		StorageClass:    c.String("storage-class"),
+		UsePathRequest:  c.Bool("use-path-request"),
+		CredentialsPath: c.String("credentials"),
+		Profile:         c.String("profile"),
+		UseContentType:  c.Bool("use-content-type"),
 
 		// Debugging,
 		DebugFuse:  c.Bool("debug_fuse"),

--- a/main.go
+++ b/main.go
@@ -73,14 +73,16 @@ func mount(
 	mountPoint string,
 	flags *FlagStorage) (mfs *fuse.MountedFileSystem, err error) {
 
+	credentialProvider := credentials.SharedCredentialsProvider{
+		Filename: flags.CredentialsPath,
+		Profile:  flags.Profile,
+	}
+
 	awsConfig := &aws.Config{
 		Region:      &flags.Region,
 		Logger:      GetLogger("s3"),
+		Credentials: credentials.NewCredentials(&credentialProvider),
 		//LogLevel: aws.LogLevel(aws.LogDebug),
-	}
-
-	if len(flags.Profile) > 0 {
-		awsConfig.Credentials = credentials.NewSharedCredentials(os.Getenv("HOME")+"/.aws/credentials", flags.Profile)
 	}
 
 	if len(flags.Endpoint) > 0 {


### PR DESCRIPTION
This resolves an edge case where we were unable to specify a custom credentials path with `AWS_SHARED_CREDENTIALS_FILE` while also specifying `--profile`.

Before, on a system where `$HOME/.aws/credentials` doesn't exist but `~/.aws/custom-creds` is available:
```
$ AWS_SHARED_CREDENTIALS_FILE=~/.aws/custom-creds goofys -f --profile foo bucket ~/s3
2016/06/24 22:19:38.749413 main.ERROR Unable to access 'bucket': invalid argument
2016/06/24 22:19:38.749664 main.FATAL Mounting file system: Mount: initialization failed
```

Now:
```
$ AWS_SHARED_CREDENTIALS_FILE=~/.aws/custom-creds goofys -f --profile foo bucket ~/s3
2016/06/24 22:18:36.171359 main.INFO File system has been successfully mounted.
```

As a side-effect this is more portable to Windows, too, I guess. See https://github.com/aws/aws-sdk-go/blob/master/aws/credentials/shared_credentials_provider.go#L27 for more detail.

Also adds a `--credentials` option to specify a custom path and extends `.gitignore` to be a little more vim-friendly.