### PR TITLE
Also expire inode cache on unlink

### DIFF
--- a/internal/goofys.go
+++ b/internal/goofys.go
@@ -932,6 +932,12 @@ func (fs *Goofys) Unlink(
 	fs.mu.Unlock()
 
 	err = parent.Unlink(fs, op.Name)
+	if err == nil {
+		fs.mu.Lock()
+		fullName := parent.getChildName(op.Name)
+		delete(fs.inodesCache, fullName)
+		fs.mu.Unlock()
+	}
 	return
 }
 

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-#set -o xtrace
+set -o xtrace
 set -o errexit
 set -o nounset
 
 function cleanup {
     if [ "$PROXY_PID" != "" ]; then
-        kill $PROXY_PID
+        kill "$PROXY_PID"
     fi
 }
 
@@ -22,7 +22,7 @@ mkdir -p /tmp/s3proxy
 
 export LOG_LEVEL=warn
 PROXY_BIN="java -jar s3proxy.jar --properties test/s3proxy.properties"
-stdbuf -oL -eL $PROXY_BIN &
+$PROXY_BIN >/dev/null 2>/dev/null &
 PROXY_PID=$!
 
 go test -timeout 20m -v $(go list ./... | grep -v /vendor/) $T


### PR DESCRIPTION
This should resolve an issue where files couldn't be moved/copied from within the GUI in OS X. Similar to #88.

`mv` and `cp` worked fine for me but when I tried to do similar operations from the Finder I consistently got errors about the file already existing ("The operation can’t be completed because an item with the name “some-file copy” already exists").

I suspected this was due to a caching problem and to confirm I set TTLs to 0 and was able to successfully move the files around.

I looked into the fuse logs and (as far as I can tell) in order to duplicate a file the Finder will first create a 0-byte placeholder at the path it intends to write to, unlink it, and then actually write contents to that path. We weren't clearing the inode cache on the unlink step, so this caused the Finder to think it was overwriting something.