### PR TITLE
Feature/sse kms

### DIFF
--- a/internal/flags.go
+++ b/internal/flags.go
@@ -262,7 +262,8 @@ func PopulateFlags(c *cli.Context) (flags *FlagStorage) {
 		UsePathRequest: c.Bool("use-path-request"),
 		Profile:        c.String("profile"),
 		UseContentType: c.Bool("use-content-type"),
-		UseSSE:         c.Bool("use-sse"),		
+		UseSSE:         c.Bool("use-sse"),
+		SSEType:        "AES256",
 
 		// Debugging,
 		DebugFuse:  c.Bool("debug_fuse"),

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -21,6 +21,8 @@ import (
 	"time"
 
 	"github.com/codegangsta/cli"
+
+	"github.com/aws/aws-sdk-go/service/s3"
 )
 
 // Set up custom help text for goofys; in particular the usage section.
@@ -272,7 +274,7 @@ func PopulateFlags(c *cli.Context) (flags *FlagStorage) {
 
 	// Set appropriate SSE type based on boolean flags
 	if flags.UseSSE {
-		flags.SSEType = ServerSideEncryptionAes256 //SSE header string for non-KMS server-side encryption (SSE-S3)
+		flags.SSEType = s3.ServerSideEncryptionAes256 //SSE header string for non-KMS server-side encryption (SSE-S3)
 	}
 
 	// Handle the repeated "-o" flag.

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -272,7 +272,7 @@ func PopulateFlags(c *cli.Context) (flags *FlagStorage) {
 
 	// Set appropriate SSE type based on boolean flags
 	if flags.UseSSE {
-		flags.SSEType = "AES256"
+		flags.SSEType = "AES256" //SSE header string for non-KMS server-side encryption (SSE-S3)
 	}
 
 	// Handle the repeated "-o" flag.

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -279,7 +279,6 @@ func PopulateFlags(c *cli.Context) (flags *FlagStorage) {
 		Profile:        c.String("profile"),
 		UseContentType: c.Bool("use-content-type"),
 		UseSSE:         c.Bool("use-sse"),
-		UseKMS:         c.Bool("use-kms"),
 		KMSKeyID:       c.String("kms-key-id"),
 
 		// Debugging,
@@ -289,11 +288,15 @@ func PopulateFlags(c *cli.Context) (flags *FlagStorage) {
 	}
 
 	// Set appropriate SSE type based on boolean flags
+	//
 	if flags.UseSSE {
 		flags.SSEType = s3.ServerSideEncryptionAes256 //SSE header string for non-KMS server-side encryption (SSE-S3)
-	}
-	if flags.UseSSE && flags.UseKMS {
-		flags.SSEType = s3.ServerSideEncryptionAwsKms //SSE header string for KMS server-side encryption (SSE-KMS)
+
+		// Only enable KMS is SSE is true
+		flags.UseKMS = c.Bool("use-kms")
+		if flags.UseKMS {
+			flags.SSEType = s3.ServerSideEncryptionAwsKms //SSE header string for KMS server-side encryption (SSE-KMS)
+		}
 	}
 
 	// Handle the repeated "-o" flag.

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -147,18 +147,18 @@ func NewApp() (app *cli.App) {
 			/// See http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html
 			cli.BoolFlag{
 				Name:  "use-sse",
-				Usage: "Enable encryption at rest in S3 for all writes; without other flags, it will use AWS managed keys (SSE-S3) (default: off)",
+				Usage: "Enable basic server-side encryption at rest (SSE-S3)in S3 for all writes (default: off)",
 			},
 
 			cli.BoolFlag{
 				Name:  "use-kms",
-				Usage: "Enable KMS encryption at rest in S3 for all writes; without other flags, it will use AWS managed keys (SSE-KMS) (default: off)",
+				Usage: "If use-sse is set, then enable KMS encryption (SSE-KMS) for all writes (default: off)",
 			},
 
 			cli.StringFlag{
 				Name:  "kms-key-id",
 				Value: "",
-				Usage: "If use-kms if set, use this particular KMS to encrypt (SSE-KMS) (default: empty)",
+				Usage: "If use-kms if set, use this particular KMS key to encrypt (SSE-KMS). If not set, use the account's CMK - customer master key (default: empty)",
 			},
 
 

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -141,6 +141,13 @@ func NewApp() (app *cli.App) {
 				Usage: "Set Content-Type according to file extension and /etc/mime.types (default: off)",
 			},
 
+			/// http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html
+			/// See http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html
+			cli.BoolFlag{
+				Name:  "use-sse",
+				Usage: "Enable encryption at rest in S3 for all writes; without other flags, it will use AWS managed keys (SSE-S3) (default: off)",
+			},
+
 			/////////////////////////
 			// Tuning
 			/////////////////////////
@@ -197,6 +204,8 @@ type FlagStorage struct {
 	UsePathRequest bool
 	Profile        string
 	UseContentType bool
+	UseSSE         bool
+	SSEType        string
 
 	// Tuning
 	StatCacheTTL time.Duration
@@ -253,11 +262,17 @@ func PopulateFlags(c *cli.Context) (flags *FlagStorage) {
 		UsePathRequest: c.Bool("use-path-request"),
 		Profile:        c.String("profile"),
 		UseContentType: c.Bool("use-content-type"),
+		UseSSE:         c.Bool("use-sse"),		
 
 		// Debugging,
 		DebugFuse:  c.Bool("debug_fuse"),
 		DebugS3:    c.Bool("debug_s3"),
 		Foreground: c.Bool("f"),
+	}
+
+	// Set appropriate SSE type based on boolean flags
+	if flags.UseSSE {
+		flags.SSEType = "AES256"
 	}
 
 	// Handle the repeated "-o" flag.

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -263,7 +263,6 @@ func PopulateFlags(c *cli.Context) (flags *FlagStorage) {
 		Profile:        c.String("profile"),
 		UseContentType: c.Bool("use-content-type"),
 		UseSSE:         c.Bool("use-sse"),
-		SSEType:        "AES256",
 
 		// Debugging,
 		DebugFuse:  c.Bool("debug_fuse"),
@@ -273,7 +272,7 @@ func PopulateFlags(c *cli.Context) (flags *FlagStorage) {
 
 	// Set appropriate SSE type based on boolean flags
 	if flags.UseSSE {
-		flags.SSEType = "AES256" //SSE header string for non-KMS server-side encryption (SSE-S3)
+		flags.SSEType = ServerSideEncryptionAes256 //SSE header string for non-KMS server-side encryption (SSE-S3)
 	}
 
 	// Handle the repeated "-o" flag.

--- a/internal/goofys.go
+++ b/internal/goofys.go
@@ -462,6 +462,7 @@ func (fs *Goofys) copyObjectMultipart(size int64, from string, to string, mpuId 
 			Key:          fs.key(to),
 			StorageClass: &fs.flags.StorageClass,
 			ContentType:  fs.getMimeType(to),
+			ServerSideEncryption: &fs.flags.SSEType,   
 		}
 
 		resp, err := fs.s3.CreateMultipartUpload(params)
@@ -529,6 +530,7 @@ func (fs *Goofys) copyObjectMaybeMultipart(size int64, from string, to string) (
 		Key:          fs.key(to),
 		StorageClass: &fs.flags.StorageClass,
 		ContentType:  fs.getMimeType(to),
+		ServerSideEncryption: &fs.flags.SSEType, 
 	}
 
 	_, err = fs.s3.CopyObject(params)

--- a/internal/goofys.go
+++ b/internal/goofys.go
@@ -462,7 +462,7 @@ func (fs *Goofys) copyObjectMultipart(size int64, from string, to string, mpuId 
 			Key:          fs.key(to),
 			StorageClass: &fs.flags.StorageClass,
 			ContentType:  fs.getMimeType(to),
-			ServerSideEncryption: &fs.flags.SSEType,   
+			ServerSideEncryption:  aws.String("AES256"), //&fs.flags.SSEType,   
 		}
 
 		resp, err := fs.s3.CreateMultipartUpload(params)
@@ -530,7 +530,7 @@ func (fs *Goofys) copyObjectMaybeMultipart(size int64, from string, to string) (
 		Key:          fs.key(to),
 		StorageClass: &fs.flags.StorageClass,
 		ContentType:  fs.getMimeType(to),
-		ServerSideEncryption: &fs.flags.SSEType, 
+		ServerSideEncryption:  aws.String("AES256"),  //&fs.flags.SSEType, 
 	}
 
 	_, err = fs.s3.CopyObject(params)

--- a/internal/goofys.go
+++ b/internal/goofys.go
@@ -462,12 +462,15 @@ func (fs *Goofys) copyObjectMultipart(size int64, from string, to string, mpuId 
 			Key:          fs.key(to),
 			StorageClass: &fs.flags.StorageClass,
 			ContentType:  fs.getMimeType(to),
-			ServerSideEncryption:  &fs.flags.SSEType,
 		}
 
 		if  fs.flags.UseSSE  {
 			params.ServerSideEncryption = &fs.flags.SSEType
+			if fs.flags.UseKMS {
+				params.SSEKMSKeyId = &fs.flags.KMSKeyID
+			}
 		}
+
 
 		resp, err := fs.s3.CreateMultipartUpload(params)
 		if err != nil {
@@ -538,6 +541,9 @@ func (fs *Goofys) copyObjectMaybeMultipart(size int64, from string, to string) (
 
 	if  fs.flags.UseSSE  {
 		params.ServerSideEncryption = &fs.flags.SSEType
+		if fs.flags.UseKMS {
+			params.SSEKMSKeyId = &fs.flags.KMSKeyID
+		}
 	}
 
 	_, err = fs.s3.CopyObject(params)

--- a/internal/goofys.go
+++ b/internal/goofys.go
@@ -466,7 +466,7 @@ func (fs *Goofys) copyObjectMultipart(size int64, from string, to string, mpuId 
 
 		if  fs.flags.UseSSE  {
 			params.ServerSideEncryption = &fs.flags.SSEType
-			if fs.flags.UseKMS &&  fs.flags.KMSKeyID != "" {
+			if fs.flags.UseKMS && fs.flags.KMSKeyID != "" {
 				params.SSEKMSKeyId = &fs.flags.KMSKeyID
 			}
 		}
@@ -541,7 +541,7 @@ func (fs *Goofys) copyObjectMaybeMultipart(size int64, from string, to string) (
 
 	if  fs.flags.UseSSE  {
 		params.ServerSideEncryption = &fs.flags.SSEType
-		if fs.flags.UseKMS &&  fs.flags.KMSKeyID != "" {
+		if fs.flags.UseKMS && fs.flags.KMSKeyID != "" {
 			params.SSEKMSKeyId = &fs.flags.KMSKeyID
 		}
 	}

--- a/internal/goofys.go
+++ b/internal/goofys.go
@@ -462,7 +462,7 @@ func (fs *Goofys) copyObjectMultipart(size int64, from string, to string, mpuId 
 			Key:          fs.key(to),
 			StorageClass: &fs.flags.StorageClass,
 			ContentType:  fs.getMimeType(to),
-			ServerSideEncryption:  aws.String("AES256"), //&fs.flags.SSEType,   
+			ServerSideEncryption:  &fs.flags.SSEType,
 		}
 
 		resp, err := fs.s3.CreateMultipartUpload(params)
@@ -530,7 +530,7 @@ func (fs *Goofys) copyObjectMaybeMultipart(size int64, from string, to string) (
 		Key:          fs.key(to),
 		StorageClass: &fs.flags.StorageClass,
 		ContentType:  fs.getMimeType(to),
-		ServerSideEncryption:  aws.String("AES256"),  //&fs.flags.SSEType, 
+		ServerSideEncryption: &fs.flags.SSEType,
 	}
 
 	_, err = fs.s3.CopyObject(params)

--- a/internal/goofys.go
+++ b/internal/goofys.go
@@ -466,7 +466,7 @@ func (fs *Goofys) copyObjectMultipart(size int64, from string, to string, mpuId 
 
 		if  fs.flags.UseSSE  {
 			params.ServerSideEncryption = &fs.flags.SSEType
-			if fs.flags.UseKMS {
+			if fs.flags.UseKMS &&  fs.flags.KMSKeyID != "" {
 				params.SSEKMSKeyId = &fs.flags.KMSKeyID
 			}
 		}
@@ -541,7 +541,7 @@ func (fs *Goofys) copyObjectMaybeMultipart(size int64, from string, to string) (
 
 	if  fs.flags.UseSSE  {
 		params.ServerSideEncryption = &fs.flags.SSEType
-		if fs.flags.UseKMS {
+		if fs.flags.UseKMS &&  fs.flags.KMSKeyID != "" {
 			params.SSEKMSKeyId = &fs.flags.KMSKeyID
 		}
 	}

--- a/internal/goofys.go
+++ b/internal/goofys.go
@@ -465,6 +465,10 @@ func (fs *Goofys) copyObjectMultipart(size int64, from string, to string, mpuId 
 			ServerSideEncryption:  &fs.flags.SSEType,
 		}
 
+		if  fs.flags.UseSSE  {
+			params.ServerSideEncryption = &fs.flags.SSEType
+		}
+
 		resp, err := fs.s3.CreateMultipartUpload(params)
 		if err != nil {
 			return mapAwsError(err)
@@ -530,7 +534,10 @@ func (fs *Goofys) copyObjectMaybeMultipart(size int64, from string, to string) (
 		Key:          fs.key(to),
 		StorageClass: &fs.flags.StorageClass,
 		ContentType:  fs.getMimeType(to),
-		ServerSideEncryption: &fs.flags.SSEType,
+	}
+
+	if  fs.flags.UseSSE  {
+		params.ServerSideEncryption = &fs.flags.SSEType
 	}
 
 	_, err = fs.s3.CopyObject(params)

--- a/internal/handles.go
+++ b/internal/handles.go
@@ -369,6 +369,9 @@ func (fh *FileHandle) initMPU(fs *Goofys) {
 
 	if  fs.flags.UseSSE  {
 		params.ServerSideEncryption = &fs.flags.SSEType
+		if fs.flags.UseKMS {
+			params.SSEKMSKeyId = &fs.flags.KMSKeyID
+		}
 	}
 
 	resp, err := fs.s3.CreateMultipartUpload(params)
@@ -861,6 +864,9 @@ func (fh *FileHandle) flushSmallFile(fs *Goofys) (err error) {
 
 	if  fs.flags.UseSSE  {
 		params.ServerSideEncryption = &fs.flags.SSEType
+		if fs.flags.UseKMS {
+			params.SSEKMSKeyId = &fs.flags.KMSKeyID
+		}
 	}
 
 	fs.replicators.Take(1, true)

--- a/internal/handles.go
+++ b/internal/handles.go
@@ -365,7 +365,7 @@ func (fh *FileHandle) initMPU(fs *Goofys) {
 		Key:          fs.key(*fh.inode.FullName),
 		StorageClass: &fs.flags.StorageClass,
 		ContentType:  fs.getMimeType(*fh.inode.FullName),
-		ServerSideEncryption:  aws.String("AES256"),  //&fs.flags.SSEType,
+		ServerSideEncryption:  &fs.flags.SSEType,
 	}
 
 	resp, err := fs.s3.CreateMultipartUpload(params)
@@ -854,7 +854,7 @@ func (fh *FileHandle) flushSmallFile(fs *Goofys) (err error) {
 		Body:         buf,
 		StorageClass: &fs.flags.StorageClass,
 		ContentType:  fs.getMimeType(*fh.inode.FullName),
-		ServerSideEncryption:  aws.String("AES256"),  //&fs.flags.SSEType,
+		ServerSideEncryption:  &fs.flags.SSEType,
 	}
 
 	fs.replicators.Take(1, true)

--- a/internal/handles.go
+++ b/internal/handles.go
@@ -369,7 +369,7 @@ func (fh *FileHandle) initMPU(fs *Goofys) {
 
 	if  fs.flags.UseSSE  {
 		params.ServerSideEncryption = &fs.flags.SSEType
-		if fs.flags.UseKMS &&  fs.flags.KMSKeyID != "" {
+		if fs.flags.UseKMS && fs.flags.KMSKeyID != "" {
 			params.SSEKMSKeyId = &fs.flags.KMSKeyID
 		}
 	}
@@ -864,7 +864,7 @@ func (fh *FileHandle) flushSmallFile(fs *Goofys) (err error) {
 
 	if  fs.flags.UseSSE  {
 		params.ServerSideEncryption = &fs.flags.SSEType
-		if fs.flags.UseKMS &&  fs.flags.KMSKeyID != "" {
+		if fs.flags.UseKMS && fs.flags.KMSKeyID != "" {
 			params.SSEKMSKeyId = &fs.flags.KMSKeyID
 		}
 	}

--- a/internal/handles.go
+++ b/internal/handles.go
@@ -365,6 +365,7 @@ func (fh *FileHandle) initMPU(fs *Goofys) {
 		Key:          fs.key(*fh.inode.FullName),
 		StorageClass: &fs.flags.StorageClass,
 		ContentType:  fs.getMimeType(*fh.inode.FullName),
+		ServerSideEncryption:  aws.String("AES256"),  //&fs.flags.SSEType,
 	}
 
 	resp, err := fs.s3.CreateMultipartUpload(params)
@@ -853,6 +854,7 @@ func (fh *FileHandle) flushSmallFile(fs *Goofys) (err error) {
 		Body:         buf,
 		StorageClass: &fs.flags.StorageClass,
 		ContentType:  fs.getMimeType(*fh.inode.FullName),
+		ServerSideEncryption:  aws.String("AES256"),  //&fs.flags.SSEType,
 	}
 
 	fs.replicators.Take(1, true)

--- a/internal/handles.go
+++ b/internal/handles.go
@@ -369,7 +369,7 @@ func (fh *FileHandle) initMPU(fs *Goofys) {
 
 	if  fs.flags.UseSSE  {
 		params.ServerSideEncryption = &fs.flags.SSEType
-		if fs.flags.UseKMS {
+		if fs.flags.UseKMS &&  fs.flags.KMSKeyID != "" {
 			params.SSEKMSKeyId = &fs.flags.KMSKeyID
 		}
 	}
@@ -864,7 +864,7 @@ func (fh *FileHandle) flushSmallFile(fs *Goofys) (err error) {
 
 	if  fs.flags.UseSSE  {
 		params.ServerSideEncryption = &fs.flags.SSEType
-		if fs.flags.UseKMS {
+		if fs.flags.UseKMS &&  fs.flags.KMSKeyID != "" {
 			params.SSEKMSKeyId = &fs.flags.KMSKeyID
 		}
 	}

--- a/internal/handles.go
+++ b/internal/handles.go
@@ -365,7 +365,10 @@ func (fh *FileHandle) initMPU(fs *Goofys) {
 		Key:          fs.key(*fh.inode.FullName),
 		StorageClass: &fs.flags.StorageClass,
 		ContentType:  fs.getMimeType(*fh.inode.FullName),
-		ServerSideEncryption:  &fs.flags.SSEType,
+	}
+
+	if  fs.flags.UseSSE  {
+		params.ServerSideEncryption = &fs.flags.SSEType
 	}
 
 	resp, err := fs.s3.CreateMultipartUpload(params)
@@ -854,7 +857,10 @@ func (fh *FileHandle) flushSmallFile(fs *Goofys) (err error) {
 		Body:         buf,
 		StorageClass: &fs.flags.StorageClass,
 		ContentType:  fs.getMimeType(*fh.inode.FullName),
-		ServerSideEncryption:  &fs.flags.SSEType,
+	}
+
+	if  fs.flags.UseSSE  {
+		params.ServerSideEncryption = &fs.flags.SSEType
 	}
 
 	fs.replicators.Take(1, true)


### PR DESCRIPTION
For Issue https://github.com/kahing/goofys/issues/102

This builds on the PR for SSE-S3.

Adds two more options: `--use-kms` and `--kms-key-id` with expanded options for server side encryption of objects in S3. 

* Requires that `--use-sse` is specified. 
* When only  the `--use-kms` is given, then uses the KMS server-side encryption mode (SSE-KMS) but with the default, customer master key (CMK).
* When `--kms-key-id` is specified in addition to `--use-kms` it use use that specified KMS instead of the master key. Requires that the user that is connected to S3 via goofys has permission to access and use that KMS key.

All three cases tested in  basic fashion with small and large file sizes.