### PR TITLE
Adds a new --acl option that allows to set the canned ACL to be applied to the object

### DIFF
--- a/internal/flags.go
+++ b/internal/flags.go
@@ -154,6 +154,13 @@ func NewApp() (app *cli.App) {
 				Value: "",
 			},
 
+			/// http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl
+			cli.StringFlag{
+				Name:  "acl",
+				Usage: "The canned ACL to apply to the object (default: off, possible values: private, public-read, public-read-write, authenticated-read, aws-exec-read, bucket-owner-read, bucket-owner-full-control)",
+				Value: "",
+			},
+
 			/////////////////////////
 			// Tuning
 			/////////////////////////
@@ -214,6 +221,7 @@ type FlagStorage struct {
 	UseSSE         bool
 	UseKMS         bool
 	KMSKeyID       string
+	ACL            string
 
 	// Tuning
 	StatCacheTTL time.Duration
@@ -274,6 +282,7 @@ func PopulateFlags(c *cli.Context) (flags *FlagStorage) {
 		UseSSE:         c.Bool("sse"),
 		UseKMS:         c.IsSet("sse-kms"),
 		KMSKeyID:       c.String("sse-kms"),
+		ACL:            c.String("acl"),
 
 		// Debugging,
 		DebugFuse:  c.Bool("debug_fuse"),

--- a/internal/goofys.go
+++ b/internal/goofys.go
@@ -572,6 +572,10 @@ func (fs *Goofys) copyObjectMultipart(size int64, from string, to string, mpuId 
 			}
 		}
 
+		if fs.flags.ACL != "" {
+			params.ACL = &fs.flags.ACL
+		}
+
 		resp, err := fs.s3.CreateMultipartUpload(params)
 		if err != nil {
 			return mapAwsError(err)
@@ -651,6 +655,10 @@ func (fs *Goofys) copyObjectMaybeMultipart(size int64, from string, to string) (
 		if fs.flags.UseKMS && fs.flags.KMSKeyID != "" {
 			params.SSEKMSKeyId = &fs.flags.KMSKeyID
 		}
+	}
+
+	if fs.flags.ACL != "" {
+		params.ACL = &fs.flags.ACL
 	}
 
 	_, err = fs.s3.CopyObject(params)

--- a/internal/handles.go
+++ b/internal/handles.go
@@ -391,6 +391,10 @@ func (fh *FileHandle) initMPU(fs *Goofys) {
 		}
 	}
 
+	if fs.flags.ACL != "" {
+		params.ACL = &fs.flags.ACL
+	}
+
 	resp, err := fs.s3.CreateMultipartUpload(params)
 
 	fh.mu.Lock()
@@ -890,6 +894,10 @@ func (fh *FileHandle) flushSmallFile(fs *Goofys) (err error) {
 		if fs.flags.UseKMS && fs.flags.KMSKeyID != "" {
 			params.SSEKMSKeyId = &fs.flags.KMSKeyID
 		}
+	}
+
+	if fs.flags.ACL != "" {
+		params.ACL = &fs.flags.ACL
 	}
 
 	fs.replicators.Take(1, true)


### PR DESCRIPTION
Default is off. Allowed values are private | public-read |
public-read-write | authenticated-read | aws-exec-read | bucket-owner-read
| bucket-owner-full-control.