### PR TITLE
Add mnt-mode option to support chroot usage

### DIFF
--- a/internal/flags.go
+++ b/internal/flags.go
@@ -92,6 +92,12 @@ func NewApp() (app *cli.App) {
 			},
 
 			cli.IntFlag{
+				Name:  "mnt-mode",
+				Value: 0755,
+				Usage: "Permission bits for the mount point. (default: 0755)",
+			},
+			
+			cli.IntFlag{
 				Name:  "dir-mode",
 				Value: 0755,
 				Usage: "Permission bits for directories. (default: 0755)",
@@ -236,6 +242,7 @@ func NewApp() (app *cli.App) {
 type FlagStorage struct {
 	// File system
 	MountOptions map[string]string
+	MntMode      os.FileMode
 	DirMode      os.FileMode
 	FileMode     os.FileMode
 	Uid          uint32
@@ -293,6 +300,7 @@ func PopulateFlags(c *cli.Context) (flags *FlagStorage) {
 	flags = &FlagStorage{
 		// File system
 		MountOptions: make(map[string]string),
+		MntMode:      os.FileMode(c.Int("mnt-mode")),
 		DirMode:      os.FileMode(c.Int("dir-mode")),
 		FileMode:     os.FileMode(c.Int("file-mode")),
 		Uid:          uint32(c.Int("uid")),

--- a/internal/goofys.go
+++ b/internal/goofys.go
@@ -66,6 +66,7 @@ type Goofys struct {
 	v2Signer  bool
 	sseType   string
 	rootAttrs fuseops.InodeAttributes
+	dirAttrs fuseops.InodeAttributes
 
 	bufferPool *BufferPool
 
@@ -181,6 +182,18 @@ func NewGoofys(bucket string, awsConfig *aws.Config, flags *FlagStorage) *Goofys
 
 	now := time.Now()
 	fs.rootAttrs = fuseops.InodeAttributes{
+		Size:   4096,
+		Nlink:  2,
+		Mode:   flags.MntMode | os.ModeDir,
+		Atime:  now,
+		Mtime:  now,
+		Ctime:  now,
+		Crtime: now,
+		Uid:    fs.flags.Uid,
+		Gid:    fs.flags.Gid,
+	}
+
+	fs.dirAttrs = fuseops.InodeAttributes{
 		Size:   4096,
 		Nlink:  2,
 		Mode:   flags.DirMode | os.ModeDir,
@@ -718,7 +731,7 @@ func (fs *Goofys) LookUpInodeMaybeDir(name string, fullName string) (inode *Inod
 		case resp := <-dirChan:
 			if len(resp.CommonPrefixes) != 0 || len(resp.Contents) != 0 {
 				inode = NewInode(&name, &fullName, fs.flags)
-				inode.Attributes = &fs.rootAttrs
+				inode.Attributes = &fs.dirAttrs
 				return
 			} else {
 				// 404

--- a/internal/goofys_test.go
+++ b/internal/goofys_test.go
@@ -236,6 +236,7 @@ func (s *GoofysTest) SetUpTest(t *C) {
 	uid, gid := MyUserAndGroup()
 	flags := &FlagStorage{
 		StorageClass: "STANDARD",
+		MntMode:      0700,
 		DirMode:      0700,
 		FileMode:     0700,
 		Uid:          uint32(uid),

--- a/internal/handles.go
+++ b/internal/handles.go
@@ -286,7 +286,7 @@ func (parent *Inode) MkDir(
 	defer parent.mu.Unlock()
 
 	inode = NewInode(&name, &fullName, parent.flags)
-	inode.Attributes = &fs.rootAttrs
+	inode.Attributes = &fs.dirAttrs
 
 	return
 }
@@ -1103,12 +1103,12 @@ func (dh *DirHandle) ReadDir(fs *Goofys, offset fuseops.DirOffset) (*fuseutil.Di
 	if offset == 0 {
 		e := makeDirEntry(".", fuseutil.DT_Directory)
 		e.Offset = 1
-		dh.NameToEntry["."] = fs.rootAttrs
+		dh.NameToEntry["."] = fs.dirAttrs
 		return &e, nil
 	} else if offset == 1 {
 		e := makeDirEntry("..", fuseutil.DT_Directory)
 		e.Offset = 2
-		dh.NameToEntry[".."] = fs.rootAttrs
+		dh.NameToEntry[".."] = fs.dirAttrs
 		return &e, nil
 	}
 
@@ -1163,7 +1163,7 @@ func (dh *DirHandle) ReadDir(fs *Goofys, offset fuseops.DirOffset) (*fuseutil.Di
 				continue
 			}
 			dh.Entries = append(dh.Entries, makeDirEntry(dirName, fuseutil.DT_Directory))
-			dh.NameToEntry[dirName] = fs.rootAttrs
+			dh.NameToEntry[dirName] = fs.dirAttrs
 		}
 
 		for _, obj := range resp.Contents {


### PR DESCRIPTION
This makes mnt mode a seperate option which is useful
to allow sftp/chroot to a goofys mount. By default a 'writeable'
goofys mount and 'ChrootDirectory %h' will cause sshd/sftpd to fail
with the following message:
'fatal: bad ownership or modes for chroot directory'

Running with --mnt-mode=755 makes chrooted sftp possible.

For more details see:
http://serverfault.com/questions/656753/configuring-chroot-for-sftp-users
https://github.com/s3fs-fuse/s3fs-fuse/pull/110