### PR TITLE
Use full length env variable names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ $GOPATH/bin/goofys <bucket:prefix> <mountpoint> # if you only want to mount ob
 
 Users can also configure credentials via the
 [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html)
-or the `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` environment variables.
+or the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
 
 To mount an S3 bucket on startup, make sure the credential is
 configured for `root`, and can add this to `/etc/fstab`:


### PR DESCRIPTION
Use 'AWS_ACCESS_KEY_ID' and 'AWS_SECRET_ACCESS_KEY' environment variable names
in README.md. These names match verbatim what the user sees in "Add
user", and correspond with other AWS utility configurations.
https://github.com/aws/aws-sdk-go#configuring-credentials

The underlying aws-sdk-go accepts the shorthand as a fallback, but if
the user has the full length variables set and goes to set the variables
listed in the docs thinking they are what Goofys uses, they will be in
for a suprise as the full length names take precedence. Changing the
docs to the full name- as this commit does- prevents that 'oops.'