### PR TITLE
add --no-dir-compat option to minimize LIST requests

### DIFF
--- a/internal/flags.go
+++ b/internal/flags.go
@@ -184,6 +184,11 @@ func NewApp() (app *cli.App) {
 				Usage: "Reduce S3 operation costs at the expense of some performance (default: off)",
 			},
 
+			cli.BoolFlag{
+				Name:  "no-dir-compat",
+				Usage: "Assume all directory objects are \"dir/\" (default: off)",
+			},
+
 			cli.DurationFlag{
 				Name:  "stat-cache-ttl",
 				Value: time.Minute,
@@ -229,7 +234,7 @@ func NewApp() (app *cli.App) {
 		flagCategories[f] = "aws"
 	}
 
-	for _, f := range []string{"cheap", "stat-cache-ttl", "type-cache-ttl"} {
+	for _, f := range []string{"cheap", "no-dir-compat", "stat-cache-ttl", "type-cache-ttl"} {
 		flagCategories[f] = "tuning"
 	}
 
@@ -264,6 +269,7 @@ type FlagStorage struct {
 
 	// Tuning
 	Cheap        bool
+	NoDirCompat	 bool
 	StatCacheTTL time.Duration
 	TypeCacheTTL time.Duration
 
@@ -309,6 +315,7 @@ func PopulateFlags(c *cli.Context) (flags *FlagStorage) {
 
 		// Tuning,
 		Cheap:        c.Bool("cheap"),
+		NoDirCompat:  c.Bool("no-dir-compat"),
 		StatCacheTTL: c.Duration("stat-cache-ttl"),
 		TypeCacheTTL: c.Duration("type-cache-ttl"),
 

--- a/internal/goofys.go
+++ b/internal/goofys.go
@@ -705,17 +705,21 @@ func (fs *Goofys) LookUpInodeMaybeDir(name string, fullName string) (inode *Inod
 	objectChan := make(chan s3.HeadObjectOutput, 1)
 	errDirBlobChan := make(chan error, 1)
 	dirBlobChan := make(chan s3.HeadObjectOutput, 1)
-	errDirChan := make(chan error, 1)
-	dirChan := make(chan s3.ListObjectsOutput, 1)
+	var errDirChan chan error;
+	var dirChan chan s3.ListObjectsOutput;
+
+	checking := 3
+	var checkErr [3]error
 
 	go fs.LookUpInodeNotDir(fullName, objectChan, errObjectChan)
 	if !fs.flags.Cheap {
 		go fs.LookUpInodeNotDir(fullName+"/", dirBlobChan, errDirBlobChan)
-		go fs.LookUpInodeDir(fullName, dirChan, errDirChan)
+		if !fs.flags.NoDirCompat {
+			errDirChan = make(chan error, 1)
+			dirChan = make(chan s3.ListObjectsOutput, 1)
+			go fs.LookUpInodeDir(fullName, dirChan, errDirChan)
+		}
 	}
-
-	checking := 3
-	var checkErr [3]error
 
 	for {
 		select {
@@ -774,9 +778,17 @@ func (fs *Goofys) LookUpInodeMaybeDir(name string, fullName string) (inode *Inod
 				go fs.LookUpInodeNotDir(fullName+"/", dirBlobChan, errDirBlobChan)
 			}
 		case 1:
-			if fs.flags.Cheap {
+			if fs.flags.NoDirCompat {
+				checkErr[2] = fuse.ENOENT
+				goto doneCase
+			} else if fs.flags.Cheap {
+				errDirChan = make(chan error, 1)
+				dirChan = make(chan s3.ListObjectsOutput, 1)
 				go fs.LookUpInodeDir(fullName, dirChan, errDirChan)
 			}
+			break
+		doneCase:
+		   fallthrough
 		case 0:
 			for _, e := range checkErr {
 				if e != fuse.ENOENT {


### PR DESCRIPTION
add --no-dir-compat option like s3fs's notsup_compat_dir to minimize LIST requests at the expense of compatibility

In my deployment, I have noticed an enormous number of expensive Tier1 requests. From the goofys debug logs, I traced this to redundant checks for directories not created by goofys in LookUpInodeMaybeDir. By short circuiting these checks, we can eliminate a LIST request when opening a new file.

Note this is my first time working with go, however the change is very minor and passes the tests with the cross product of options --cheap and --no-dir-compat.