### PR TITLE
Lowercase github.com/Sirupsen/logrus

### DIFF
--- a/internal/buffer_pool_test.go
+++ b/internal/buffer_pool_test.go
@@ -20,7 +20,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	. "gopkg.in/check.v1"
 )
 

--- a/internal/goofys.go
+++ b/internal/goofys.go
@@ -39,7 +39,7 @@ import (
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/fuse/fuseutil"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // goofys is a Filey System written in Go. All the backend data is

--- a/internal/goofys_test.go
+++ b/internal/goofys_test.go
@@ -45,7 +45,7 @@ import (
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/fuse/fuseutil"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	. "gopkg.in/check.v1"
 )

--- a/internal/handles.go
+++ b/internal/handles.go
@@ -30,7 +30,7 @@ import (
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/fuse/fuseutil"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 type Inode struct {

--- a/internal/logger.go
+++ b/internal/logger.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/Sirupsen/logrus"
-	logrus_syslog "github.com/Sirupsen/logrus/hooks/syslog"
+	"github.com/sirupsen/logrus"
+	logrus_syslog "github.com/sirupsen/logrus/hooks/syslog"
 )
 
 var mu sync.Mutex

--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ import (
 
 	"github.com/kardianos/osext"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	daemon "github.com/sevlyar/go-daemon"
 )


### PR DESCRIPTION
From https://github.com/sirupsen/logrus#logrus-

> Seeing weird case-sensitive problems? Unfortunately, the author failed to realize the consequences of renaming to lower-case. Due to the Go package environment, this caused issues. Regretfully, there's no turning back now. Everything using logrus will need to use the lower-case: github.com/sirupsen/logrus. Any package that isn't, should be changed.