### PR TITLE
fix readahead panic when s3 return 'permission denied'

### DIFF
--- a/internal/buffer_pool.go
+++ b/internal/buffer_pool.go
@@ -377,7 +377,9 @@ func (b *Buffer) Read(p []byte) (n int, err error) {
 		b.cond.Wait()
 	}
 
-	if b.buf != nil {
+	if b.err != nil && b.err != io.EOF {
+		err = b.err
+	} else if b.buf != nil {
 		bufferLog.Debugf("reading %v from buffer", len(p))
 
 		n, err = b.buf.Read(p)
@@ -389,8 +391,6 @@ func (b *Buffer) Read(p []byte) (n int, err error) {
 		} else {
 			bufferLog.Debugf("read %v from buffer", n)
 		}
-	} else if b.err != nil {
-		err = b.err
 	} else {
 		n, err = b.readFromStream(p)
 	}


### PR DESCRIPTION
If getobject req return err such as permission denied, the readaheader buffer Buffer struct member reader will be nil, member err = 13(permission denied).but member buf(type Mbuf) is not nil.

So when do Buffer.Read,first readfrom buf,then read from reader,which lead to panic.because reader is nil.
