### PR TITLE
Add support for Requester Pays buckets

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -37,6 +37,7 @@ type Config struct {
 	Region         string
 	RegionSet      bool
 	StorageClass   string
+	RequestPayer   bool
 	Profile        string
 	UseContentType bool
 	UseSSE         bool

--- a/api/api.go
+++ b/api/api.go
@@ -1,7 +1,7 @@
 package goofys
 
 import (
-	. "github.com/kahing/goofys/internal"
+	. "github.com/msmitherdc/goofys/internal"
 
 	"fmt"
 	"os"

--- a/api/api.go
+++ b/api/api.go
@@ -1,7 +1,7 @@
 package goofys
 
 import (
-	. "github.com/msmitherdc/goofys/internal"
+	. "github.com/kahing/goofys/internal"
 
 	"fmt"
 	"os"

--- a/internal/dir.go
+++ b/internal/dir.go
@@ -150,6 +150,10 @@ func (dh *DirHandle) listObjectsSlurp(prefix string) (resp *s3.ListObjectsOutput
 		Marker: marker,
 	}
 
+	if fs.flags.RequestPayer {
+		params.RequestPayer = aws.String("requester")
+	}	
+
 	resp, err = fs.s3.ListObjects(params)
 	if err != nil {
 		s3Log.Errorf("ListObjects %v = %v", params, err)
@@ -246,6 +250,11 @@ func (dh *DirHandle) listObjects(prefix string) (resp *s3.ListObjectsOutput, err
 			Marker:    dh.Marker,
 			Prefix:    &prefix,
 		}
+
+		if fs.flags.RequestPayer {
+			params.RequestPayer = aws.String("requester")
+		}	
+
 
 		resp, err := fs.s3.ListObjects(params)
 		if err != nil {

--- a/internal/file.go
+++ b/internal/file.go
@@ -87,8 +87,8 @@ func (fh *FileHandle) initMPU() {
 		ContentType:  fs.getMimeType(*fh.inode.FullName()),
 	}
 
-	if fs.flags.RequestPayer{
-		params.RequestPayer = "RequestPayer"
+	if fs.flags.RequestPayer {
+		params.RequestPayer = aws.String("requester")
 	}
 
 	if fs.flags.UseSSE {
@@ -140,8 +140,8 @@ func (fh *FileHandle) mpuPartNoSpawn(buf *MBuf, part int) (err error) {
 		Body:       buf,
 	}
 
-	if fs.flags.RequestPayer{
-		params.RequestPayer = "RequestPayer"
+	if fs.flags.RequestPayer {
+		params.RequestPayer = aws.String("requester")
 	}
 
 	s3Log.Debug(params)
@@ -291,8 +291,8 @@ func (b S3ReadBuffer) Init(fh *FileHandle, offset uint64, size uint32) *S3ReadBu
 			Key:    fs.key(*fh.inode.FullName()),
 		}
 
-		if fs.flags.RequestPayer{
-			params.RequestPayer = "RequestPayer"
+		if fs.flags.RequestPayer {
+			params.RequestPayer = aws.String("requester")
 		}
 
 		bytes := fmt.Sprintf("bytes=%v-%v", offset, offset+uint64(size)-1)
@@ -564,8 +564,8 @@ func (fh *FileHandle) readFromStream(offset int64, buf []byte) (bytesRead int, e
 			Key:    fs.key(*fh.inode.FullName()),
 		}
 
-		if fs.flags.RequestPayer{
-			params.RequestPayer = "RequestPayer"
+		if fs.flags.RequestPayer {
+			params.RequestPayer = aws.String("requester")
 		}
 
 		if offset != 0 {
@@ -617,8 +617,8 @@ func (fh *FileHandle) flushSmallFile() (err error) {
 		ContentType:  fs.getMimeType(*fh.inode.FullName()),
 	}
 
-	if fs.flags.RequestPayer{
-		params.RequestPayer = "RequestPayer"
+	if fs.flags.RequestPayer {
+		params.RequestPayer = aws.String("requester")
 	}	
 
 	if fs.flags.UseSSE {
@@ -679,8 +679,8 @@ func (fh *FileHandle) FlushFile() (err error) {
 						UploadId: fh.mpuId,
 					}
 
-					if fs.flags.RequestPayer{
-						params.RequestPayer = "RequestPayer"
+					if fs.flags.RequestPayer {
+						params.RequestPayer = aws.String("requester")
 					}
 
 					fh.mpuId = nil
@@ -746,8 +746,8 @@ func (fh *FileHandle) FlushFile() (err error) {
 		},
 	}
 
-	if fs.flags.RequestPayer{
-		params.RequestPayer = "RequestPayer"
+	if fs.flags.RequestPayer {
+		params.RequestPayer = aws.String("requester")
 	}
 
 	s3Log.Debug(params)

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -155,7 +155,7 @@ func NewApp() (app *cli.App) {
 			},
 			cli.BoolFlag{
 				Name:  "request-payer",
-				Usage: "Whether to allow access to requester-pays buckets (default: off)" 
+				Usage: "Whether to allow access to requester-pays buckets (default: off)",
 			},
 
 			cli.StringFlag{
@@ -362,7 +362,7 @@ func PopulateFlags(c *cli.Context) (ret *FlagStorage) {
 		Endpoint:       c.String("endpoint"),
 		Region:         c.String("region"),
 		RegionSet:      c.IsSet("region"),
-		RequestPayer    c.Bool("request-payer")
+		RequestPayer    c.Bool("request-payer"),
 		StorageClass:   c.String("storage-class"),
 		Profile:        c.String("profile"),
 		UseContentType: c.Bool("use-content-type"),

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -362,7 +362,7 @@ func PopulateFlags(c *cli.Context) (ret *FlagStorage) {
 		Endpoint:       c.String("endpoint"),
 		Region:         c.String("region"),
 		RegionSet:      c.IsSet("region"),
-		RequestPayer    c.Bool("request-payer"),
+		RequestPayer:   c.Bool("request-payer"),
 		StorageClass:   c.String("storage-class"),
 		Profile:        c.String("profile"),
 		UseContentType: c.Bool("use-content-type"),

--- a/internal/goofys.go
+++ b/internal/goofys.go
@@ -272,8 +272,8 @@ func RandStringBytesMaskImprSrc(n int) string {
 func (fs *Goofys) testBucket() (err error) {
 	randomObjectName := fs.key(RandStringBytesMaskImprSrc(32))
 
-	if fs.flags.RequestPayer{
-		_, err = fs.s3.HeadObject(&s3.HeadObjectInput{Bucket: &fs.bucket, Key: randomObjectName, RequestPayer: "RequestPayer"})
+	if fs.flags.RequestPayer {
+		_, err = fs.s3.HeadObject(&s3.HeadObjectInput{Bucket: &fs.bucket, Key: randomObjectName, RequestPayer: aws.String("requester")})
 	} else {
 	   _, err = fs.s3.HeadObject(&s3.HeadObjectInput{Bucket: &fs.bucket, Key: randomObjectName})  
     }
@@ -393,8 +393,8 @@ func (fs *Goofys) cleanUpOldMPU() {
 				UploadId: upload.UploadId,
 			}
 
-			if fs.flags.RequestPayer{
-				params.RequestPayer = "RequestPayer"
+			if fs.flags.RequestPayer {
+				params.RequestPayer = aws.String("requester")
 			}
 			
 			resp, err := fs.s3.AbortMultipartUpload(params)

--- a/main.go
+++ b/main.go
@@ -16,8 +16,8 @@
 package main
 
 import (
-	goofys "github.com/msmitherdc/goofys/api"
-	. "github.com/msmitherdc/goofys/internal"
+	goofys "github.com/kahing/goofys/api"
+	. "github.com/kahing/goofys/internal"
 
 	"fmt"
 	"os"


### PR DESCRIPTION
This adds an aws flag config option `request-payer` to set the go sdk param for accessing these buckets. 

You can use the requestor pays bucket `usgs-lidar` to test