### PR TITLE
do not use STANDARD_IA storage class for files less than 128KB

### DIFF
--- a/internal/file.go
+++ b/internal/file.go
@@ -593,11 +593,15 @@ func (fh *FileHandle) flushSmallFile() (err error) {
 
 	fs := fh.inode.fs
 
+	storageClass := fs.flags.StorageClass
+	if fh.nextWriteOffset < 128*1024 && storageClass == "STANDARD_IA" {
+		storageClass = "STANDARD"
+   }
 	params := &s3.PutObjectInput{
 		Bucket:       &fs.bucket,
 		Key:          fs.key(*fh.inode.FullName()),
 		Body:         buf,
-		StorageClass: &fs.flags.StorageClass,
+		StorageClass: &storageClass,
 		ContentType:  fs.getMimeType(*fh.inode.FullName()),
 	}
 


### PR DESCRIPTION
STANDARD_IA storage class has minimum charge of 128KB, we should not use STANDARD_IA unless the object size is greater than 128KB. This also increases cost efficiency for operations that first open an empty file and then write to it (like shell redirection).