### PR TITLE
Add support for request-payer buckets

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -38,6 +38,7 @@ type Config struct {
 	Region         string
 	RegionSet      bool
 	StorageClass   string
+	RequestPayer   bool
 	Profile        string
 	UseContentType bool
 	UseSSE         bool

--- a/internal/dir.go
+++ b/internal/dir.go
@@ -150,6 +150,10 @@ func (dh *DirHandle) listObjectsSlurp(prefix string) (resp *s3.ListObjectsOutput
 		Marker: marker,
 	}
 
+	if fs.flags.RequestPayer {
+		params.RequestPayer = aws.String("requester")
+	}	
+
 	resp, err = fs.s3.ListObjects(params)
 	if err != nil {
 		s3Log.Errorf("ListObjects %v = %v", params, err)
@@ -246,6 +250,11 @@ func (dh *DirHandle) listObjects(prefix string) (resp *s3.ListObjectsOutput, err
 			Marker:    dh.Marker,
 			Prefix:    &prefix,
 		}
+
+		if fs.flags.RequestPayer {
+			params.RequestPayer = aws.String("requester")
+		}	
+
 
 		resp, err := fs.s3.ListObjects(params)
 		if err != nil {

--- a/internal/file.go
+++ b/internal/file.go
@@ -89,6 +89,10 @@ func (fh *FileHandle) initMPU() {
 		ContentType:  fs.getMimeType(*fh.inode.FullName()),
 	}
 
+	if fs.flags.RequestPayer {
+		params.RequestPayer = aws.String("requester")
+	}
+
 	if fs.flags.UseSSE {
 		params.ServerSideEncryption = &fs.sseType
 		if fs.flags.UseKMS && fs.flags.KMSKeyID != "" {
@@ -162,6 +166,22 @@ func (fh *FileHandle) mpuPartNoSpawn(buf *MBuf, part int, total int64, last bool
 			PartNumber: aws.Int64(int64(part)),
 			UploadId:   fh.mpuId,
 			Body:       buf,
+		}
+        	
+                if fs.flags.RequestPayer{
+		    params.RequestPayer = "RequestPayer"
+	        }
+
+		if fs.flags.RequestPayer {
+			params.RequestPayer = aws.String("requester")
+		}
+
+		if fs.flags.RequestPayer {
+			params.RequestPayer = aws.String("requester")
+		}
+
+		if fs.flags.RequestPayer {
+			params.RequestPayer = aws.String("requester")
 		}
 
 		s3Log.Debug(params)
@@ -374,6 +394,10 @@ func (b S3ReadBuffer) Init(fh *FileHandle, offset uint64, size uint32) *S3ReadBu
 		params := &s3.GetObjectInput{
 			Bucket: &fs.bucket,
 			Key:    fs.key(*fh.inode.FullName()),
+		}
+
+		if fs.flags.RequestPayer {
+			params.RequestPayer = aws.String("requester")
 		}
 
 		bytes := fmt.Sprintf("bytes=%v-%v", offset, offset+uint64(size)-1)
@@ -645,6 +669,10 @@ func (fh *FileHandle) readFromStream(offset int64, buf []byte) (bytesRead int, e
 			Key:    fs.key(*fh.inode.FullName()),
 		}
 
+		if fs.flags.RequestPayer {
+			params.RequestPayer = aws.String("requester")
+		}
+
 		if offset != 0 {
 			bytes := fmt.Sprintf("bytes=%v-", offset)
 			params.Range = &bytes
@@ -698,6 +726,10 @@ func (fh *FileHandle) flushSmallFile() (err error) {
 		StorageClass: &storageClass,
 		ContentType:  fs.getMimeType(*fh.inode.FullName()),
 	}
+
+	if fs.flags.RequestPayer {
+		params.RequestPayer = aws.String("requester")
+	}	
 
 	if fs.flags.UseSSE {
 		params.ServerSideEncryption = &fs.sseType
@@ -755,6 +787,10 @@ func (fh *FileHandle) FlushFile() (err error) {
 						Bucket:   &fs.bucket,
 						Key:      fs.key(*fh.inode.FullName()),
 						UploadId: fh.mpuId,
+					}
+
+					if fs.flags.RequestPayer {
+						params.RequestPayer = aws.String("requester")
 					}
 
 					fh.mpuId = nil
@@ -820,6 +856,10 @@ func (fh *FileHandle) FlushFile() (err error) {
 				Parts: parts,
 			},
 		}
+
+	    if fs.flags.RequestPayer {
+		    params.RequestPayer = aws.String("requester")
+	    }
 
 		s3Log.Debug(params)
 

--- a/internal/file.go
+++ b/internal/file.go
@@ -167,20 +167,8 @@ func (fh *FileHandle) mpuPartNoSpawn(buf *MBuf, part int, total int64, last bool
 			UploadId:   fh.mpuId,
 			Body:       buf,
 		}
-        	
-                if fs.flags.RequestPayer{
-		    params.RequestPayer = "RequestPayer"
-	        }
 
-		if fs.flags.RequestPayer {
-			params.RequestPayer = aws.String("requester")
-		}
-
-		if fs.flags.RequestPayer {
-			params.RequestPayer = aws.String("requester")
-		}
-
-		if fs.flags.RequestPayer {
+ 		if fs.flags.RequestPayer {
 			params.RequestPayer = aws.String("requester")
 		}
 

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -153,6 +153,10 @@ func NewApp() (app *cli.App) {
 					"eu-central-1, ap-southeast-1, ap-southeast-2, ap-northeast-1, " +
 					"sa-east-1, cn-north-1",
 			},
+			cli.BoolFlag{
+				Name:  "request-payer",
+				Usage: "Whether to allow access to requester-pays buckets (default: off)",
+			},
 
 			cli.StringFlag{
 				Name:  "storage-class",
@@ -246,7 +250,7 @@ func NewApp() (app *cli.App) {
 
 	flagCategories = map[string]string{}
 
-	for _, f := range []string{"region", "sse", "sse-kms", "storage-class", "acl"} {
+	for _, f := range []string{"region", "sse", "sse-kms", "storage-class", "acl", "request-payer"} {
 		flagCategories[f] = "aws"
 	}
 
@@ -283,6 +287,7 @@ type FlagStorage struct {
 	// S3
 	Endpoint       string
 	Region         string
+	RequestPayer   bool
 	RegionSet      bool
 	StorageClass   string
 	Profile        string
@@ -357,6 +362,7 @@ func PopulateFlags(c *cli.Context) (ret *FlagStorage) {
 		Endpoint:       c.String("endpoint"),
 		Region:         c.String("region"),
 		RegionSet:      c.IsSet("region"),
+		RequestPayer:   c.Bool("request-payer"),
 		StorageClass:   c.String("storage-class"),
 		Profile:        c.String("profile"),
 		UseContentType: c.Bool("use-content-type"),

--- a/internal/goofys_test.go
+++ b/internal/goofys_test.go
@@ -2166,3 +2166,42 @@ func (s *GoofysTest) TestDirMTimeNoTTL(t *C) {
 	// setupDefaultEnv is before mounting
 	t.Assert(attr3.Mtime.Before(m2), Equals, true)
 }
+
+func (s *GoofysTest) TestStatCacheTTL(t *C) {
+	s.fs.flags.StatCacheTTL = 3 * time.Second
+	s.fs.flags.TypeCacheTTL = 3 * time.Second
+
+	mountPoint := "/tmp/mnt" + s.fs.bucket
+	s.mount(t, mountPoint)
+	defer s.umount(t, mountPoint)
+
+	key := "empty_dir/newfile"
+	file := mountPoint + "/" + key
+
+	fh, err := os.Create(file)
+	t.Assert(err, IsNil)
+
+	err = fh.Close()
+	t.Assert(err, IsNil)
+
+	_, err = s.s3.DeleteObject(&s3.DeleteObjectInput{
+		Bucket: &s.fs.bucket,
+		Key:    &key,
+	})
+	t.Assert(err, IsNil)
+
+	time.Sleep(3 * time.Second)
+
+	dh, err := os.Open(mountPoint + "/empty_dir")
+	t.Assert(err, IsNil)
+	defer func() {
+		// close the file if the test failed so we can unmount
+		if dh != nil {
+			dh.Close()
+		}
+	}()
+
+	names, err := dh.Readdirnames(0)
+	t.Assert(err, IsNil)
+	t.Assert(names, DeepEquals, []string{})
+}


### PR DESCRIPTION
Added a new parameter for a bucket, boolean, which allows a user to connect to a requester-payer bucket. Also updated the aws go sdk version due to some bugs with request payer support in the api.