### PR TITLE
Add a parameter max-keys to tuning

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -46,8 +46,10 @@ type Config struct {
 	ACL            string
 
 	// Tuning
-	Cheap        bool
-	ExplicitDir  bool
+	Cheap       bool
+	ExplicitDir bool
+	MaxKeys     int64
+
 	StatCacheTTL time.Duration
 	TypeCacheTTL time.Duration
 

--- a/internal/dir.go
+++ b/internal/dir.go
@@ -244,6 +244,7 @@ func (dh *DirHandle) listObjects(prefix string) (resp *s3.ListObjectsOutput, err
 			Bucket:    &fs.bucket,
 			Delimiter: aws.String("/"),
 			Marker:    dh.Marker,
+			MaxKeys:   aws.Int64((*fs.flags).MaxKeys),
 			Prefix:    &prefix,
 		}
 

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -204,6 +204,11 @@ func NewApp() (app *cli.App) {
 				Name:  "no-implicit-dir",
 				Usage: "Assume all directory objects (\"dir/\") exist (default: off)",
 			},
+			cli.Int64Flag{
+				Name:  "max-keys",
+				Value: int64(1000),
+				Usage: "Maximum number of keys returned per one connection in the response body",
+			},
 
 			cli.DurationFlag{
 				Name:  "stat-cache-ttl",
@@ -250,7 +255,7 @@ func NewApp() (app *cli.App) {
 		flagCategories[f] = "aws"
 	}
 
-	for _, f := range []string{"cheap", "no-implicit-dir", "stat-cache-ttl", "type-cache-ttl"} {
+	for _, f := range []string{"cheap", "no-implicit-dir", "max-keys", "stat-cache-ttl", "type-cache-ttl"} {
 		flagCategories[f] = "tuning"
 	}
 
@@ -295,6 +300,7 @@ type FlagStorage struct {
 	// Tuning
 	Cheap        bool
 	ExplicitDir  bool
+	MaxKeys      int64
 	StatCacheTTL time.Duration
 	TypeCacheTTL time.Duration
 
@@ -350,6 +356,7 @@ func PopulateFlags(c *cli.Context) (ret *FlagStorage) {
 		// Tuning,
 		Cheap:        c.Bool("cheap"),
 		ExplicitDir:  c.Bool("no-implicit-dir"),
+		MaxKeys:      c.Int64("max-keys"),
 		StatCacheTTL: c.Duration("stat-cache-ttl"),
 		TypeCacheTTL: c.Duration("type-cache-ttl"),
 


### PR DESCRIPTION
Added a new tuning parameter, max-keys (int64), for speed up ls in big buckets.