### PR TITLE
goofys when run in Docker/POD uses the HOST memory limits

### DIFF
--- a/internal/buffer_pool.go
+++ b/internal/buffer_pool.go
@@ -15,15 +15,15 @@
 package internal
 
 import (
+	"errors"
 	"io"
+	"io/ioutil"
+	"path/filepath"
 	"runtime"
 	"runtime/debug"
-	"sync"
-	"io/ioutil"
-	"strings"
 	"strconv"
-	"path/filepath"
-    "errors"
+	"strings"
+	"sync"
 
 	"github.com/jacobsa/fuse"
 	"github.com/shirou/gopsutil/mem"
@@ -50,12 +50,12 @@ func maxMemToUse(buffersNow uint64) uint64 {
 		panic(err)
 	}
 
-    availableMem, err := getCgroupAvailableMem()
+	availableMem, err := getCgroupAvailableMem()
 	log.Debugf("amount of available memory from cgroup is: %v", availableMem/1024/1024)
 
-    if(err != nil || availableMem < 0 || availableMem > m.Available) {
-        availableMem = m.Available
-    }
+	if err != nil || availableMem < 0 || availableMem > m.Available {
+		availableMem = m.Available
+	}
 
 	log.Debugf("amount of available memory: %v", availableMem/1024/1024)
 
@@ -71,81 +71,80 @@ func maxMemToUse(buffersNow uint64) uint64 {
 }
 
 const CGROUP_PATH = "/proc/self/cgroup"
-const CGROUP_FOLDER_PREFIX = "/sys/fs/cgroup/memory" 
+const CGROUP_FOLDER_PREFIX = "/sys/fs/cgroup/memory"
 const MEM_LIMIT_FILE_SUFFIX = "/memory.limit_in_bytes"
 const MEM_USAGE_FILE_SUFFIX = "/memory.usage_in_bytes"
 
 func getCgroupAvailableMem() (retVal uint64, err error) {
-    //get the memory cgroup for self and send limit - usage for the cgroup
+	//get the memory cgroup for self and send limit - usage for the cgroup
 
-    data,err := ioutil.ReadFile(CGROUP_PATH)
-    if err != nil {
-        log.Debugf("Unable to read file %s error: %s", CGROUP_PATH, err)
-        return 0, err
-    }
+	data, err := ioutil.ReadFile(CGROUP_PATH)
+	if err != nil {
+		log.Debugf("Unable to read file %s error: %s", CGROUP_PATH, err)
+		return 0, err
+	}
 
-    path, err := getMemoryCgroupPath(string(data)) 
-    if err != nil {
-        log.Debugf("Unable to get memory cgroup path") 
-        return 0, err
-    }
-    log.Debugf("the memory cgroup path for the current process is %v", path)  
+	path, err := getMemoryCgroupPath(string(data))
+	if err != nil {
+		log.Debugf("Unable to get memory cgroup path")
+		return 0, err
+	}
+	log.Debugf("the memory cgroup path for the current process is %v", path)
 
-    mem_limit, err := readFileAndGetValue(filepath.Join(CGROUP_FOLDER_PREFIX, path,  MEM_LIMIT_FILE_SUFFIX))
-    if err != nil {
-        log.Debugf("Unable to get memory limit from cgroup error: %v", err)
-        return 0, err
-    }
+	mem_limit, err := readFileAndGetValue(filepath.Join(CGROUP_FOLDER_PREFIX, path, MEM_LIMIT_FILE_SUFFIX))
+	if err != nil {
+		log.Debugf("Unable to get memory limit from cgroup error: %v", err)
+		return 0, err
+	}
 
-    mem_usage, err := readFileAndGetValue(filepath.Join(CGROUP_FOLDER_PREFIX, path, MEM_USAGE_FILE_SUFFIX))
-    if err != nil {
-        log.Debugf("Unable to get memory usage from cgroup error: %v", err)
-        return 0, err
-    }
+	mem_usage, err := readFileAndGetValue(filepath.Join(CGROUP_FOLDER_PREFIX, path, MEM_USAGE_FILE_SUFFIX))
+	if err != nil {
+		log.Debugf("Unable to get memory usage from cgroup error: %v", err)
+		return 0, err
+	}
 
-    return (mem_limit - mem_usage), nil 
+	return (mem_limit - mem_usage), nil
 }
 
 func getMemoryCgroupPath(data string) (string, error) {
- 
-    /*
-    Content of /proc/self/cgroup
 
-    11:hugetlb:/
-    10:memory:/user.slice
-    9:cpuset:/
-    8:blkio:/user.slice
-    7:perf_event:/
-    6:net_prio,net_cls:/
-    5:cpuacct,cpu:/user.slice
-    4:devices:/user.slice
-    3:freezer:/
-    2:pids:/
-    1:name=systemd:/user.slice/user-1000.slice/session-1759.scope
-    */
- 
-    dataArray := strings.Split(data, "\n")
-    for index := range dataArray {
-        kvArray := strings.Split(dataArray[index], ":")
-        if len(kvArray) == 3 {
-            if kvArray[1] == "memory" {
-                return kvArray[2], nil
-            }
-        }
-    }
+	/*
+	   Content of /proc/self/cgroup
 
-    return "", errors.New("Unable to get memory cgroup path")
+	   11:hugetlb:/
+	   10:memory:/user.slice
+	   9:cpuset:/
+	   8:blkio:/user.slice
+	   7:perf_event:/
+	   6:net_prio,net_cls:/
+	   5:cpuacct,cpu:/user.slice
+	   4:devices:/user.slice
+	   3:freezer:/
+	   2:pids:/
+	   1:name=systemd:/user.slice/user-1000.slice/session-1759.scope
+	*/
+
+	dataArray := strings.Split(data, "\n")
+	for index := range dataArray {
+		kvArray := strings.Split(dataArray[index], ":")
+		if len(kvArray) == 3 {
+			if kvArray[1] == "memory" {
+				return kvArray[2], nil
+			}
+		}
+	}
+
+	return "", errors.New("Unable to get memory cgroup path")
 }
 
-
 func readFileAndGetValue(path string) (uint64, error) {
-    data,err := ioutil.ReadFile(path)
-    if err != nil {
-	    log.Debugf("Unable to read file %v error: %v", path, err)
-        return 0, err
-    }
- 
-    return strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		log.Debugf("Unable to read file %v error: %v", path, err)
+		return 0, err
+	}
+
+	return strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
 }
 
 func rounduUp(size uint64, pageSize int) int {

--- a/internal/buffer_pool.go
+++ b/internal/buffer_pool.go
@@ -19,6 +19,11 @@ import (
 	"runtime"
 	"runtime/debug"
 	"sync"
+	"io/ioutil"
+	"strings"
+	"math"
+	"strconv"
+	"path/filepath"
 
 	"github.com/jacobsa/fuse"
 	"github.com/shirou/gopsutil/mem"
@@ -45,17 +50,105 @@ func maxMemToUse(buffersNow uint64) uint64 {
 		panic(err)
 	}
 
-	log.Debugf("amount of available memory: %v", m.Available/1024/1024)
+    availableMem := getCgroupAvailableMem()
+	log.Debugf("amount of available memory from cgroup is: %v", availableMem/1024/1024)
+
+    if(availableMem < 0 || availableMem > m.Available) {
+        availableMem = m.Available
+    }
+
+	log.Debugf("amount of available memory: %v", availableMem/1024/1024)
 
 	var ms runtime.MemStats
 	runtime.ReadMemStats(&ms)
 
 	log.Debugf("amount of allocated memory: %v %v", ms.Sys/1024/1024, ms.Alloc/1024/1024)
 
-	max := uint64(m.Available+ms.Sys) / 2
+	max := uint64(availableMem+ms.Sys) / 2
 	maxbuffers := MaxUInt64(max/BUF_SIZE, 1)
 	log.Debugf("using up to %v %vMB buffers, now is %v", maxbuffers, BUF_SIZE/1024/1024, buffersNow)
 	return maxbuffers
+}
+
+const CGROUP_PATH = "/proc/self/cgroup"
+const CGROUP_FOLDER_PREFIX = "/sys/fs/cgroup/memory" 
+const MEM_LIMIT_FILE_SUFFIX = "/memory.limit_in_bytes"
+const MEM_USAGE_FILE_SUFFIX = "/memory.max_usage_in_bytes"
+
+func getCgroupAvailableMem() (retVal uint64) {
+    //get the memory cgroup for self and send limit - usage for the cgroup
+
+    //Return this value in error case
+    retVal = math.MaxUint64
+ 
+    data,err := ioutil.ReadFile(CGROUP_PATH)
+    if err != nil {
+        log.Debugf("Unable to read file %s error: %s", CGROUP_PATH, err)
+        return
+    }
+
+    path := getMemoryCgroupPath(string(data)) 
+    if path == "" {
+        log.Debugf("Unable to get memory cgroup path") 
+        return
+    }
+    log.Debugf("the memory cgroup path for the current process is %v", path)  
+
+    mem_limit, err := readFileAndGetValue(filepath.Join(CGROUP_FOLDER_PREFIX, path,  MEM_LIMIT_FILE_SUFFIX))
+    if err != nil {
+        log.Debugf("Unable to get memory limit from cgroup error: %v", err)
+        return
+    }
+
+    mem_usage, err := readFileAndGetValue(filepath.Join(CGROUP_FOLDER_PREFIX, path, MEM_USAGE_FILE_SUFFIX))
+    if err != nil {
+        log.Debugf("Unable to get memory usage from cgroup error: %v", err)
+        return
+    }
+
+    return (mem_limit - mem_usage)
+}
+
+func getMemoryCgroupPath(data string) string {
+ 
+    /*
+    Content of /proc/self/cgroup
+
+    11:hugetlb:/
+    10:memory:/user.slice
+    9:cpuset:/
+    8:blkio:/user.slice
+    7:perf_event:/
+    6:net_prio,net_cls:/
+    5:cpuacct,cpu:/user.slice
+    4:devices:/user.slice
+    3:freezer:/
+    2:pids:/
+    1:name=systemd:/user.slice/user-1000.slice/session-1759.scope
+    */
+ 
+    dataArray := strings.Split(data, "\n")
+    for index := range dataArray {
+        kvArray := strings.Split(dataArray[index], ":")
+        if len(kvArray) == 3 {
+            if kvArray[1] == "memory" {
+                return kvArray[2]
+            }
+        }
+    }
+
+    return ""
+}
+
+
+func readFileAndGetValue(path string) (uint64, error) {
+    data,err := ioutil.ReadFile(path)
+    if err != nil {
+	    log.Debugf("Unable to read file %v error: %v", path, err)
+        return 0, err
+    }
+ 
+    return strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
 }
 
 func rounduUp(size uint64, pageSize int) int {

--- a/internal/buffer_pool_test.go
+++ b/internal/buffer_pool_test.go
@@ -257,3 +257,20 @@ func (s *BufferTest) TestIssue193(t *C) {
 
 	// readloop would have caused a panic
 }
+
+func (s *BufferTest) TestCGroupMemory(t *C) {
+    //test getMemoryCgroupPath()
+    test_input :=  `11:hugetlb:/
+                    10:memory:/user.slice
+                    9:cpuset:/
+                    8:blkio:/user.slice
+                    7:perf_event:/
+                    6:net_prio,net_cls:/
+                    5:cpuacct,cpu:/user.slice
+                    4:devices:/user.slice
+                    3:freezer:/
+                    2:pids:/
+                    1:name=systemd:/user.slice/user-1000.slice/session-1759.scope`
+    mem_path := getMemoryCgroupPath(test_input)
+    t.Assert(mem_path, Equals, "/user.slice")
+}

--- a/internal/buffer_pool_test.go
+++ b/internal/buffer_pool_test.go
@@ -259,8 +259,8 @@ func (s *BufferTest) TestIssue193(t *C) {
 }
 
 func (s *BufferTest) TestCGroupMemory(t *C) {
-    //test getMemoryCgroupPath()
-    test_input :=  `11:hugetlb:/
+	//test getMemoryCgroupPath()
+	test_input := `11:hugetlb:/
                     10:memory:/user.slice
                     9:cpuset:/
                     8:blkio:/user.slice
@@ -271,6 +271,6 @@ func (s *BufferTest) TestCGroupMemory(t *C) {
                     3:freezer:/
                     2:pids:/
                     1:name=systemd:/user.slice/user-1000.slice/session-1759.scope`
-    mem_path, _ := getMemoryCgroupPath(test_input)
-    t.Assert(mem_path, Equals, "/user.slice")
+	mem_path, _ := getMemoryCgroupPath(test_input)
+	t.Assert(mem_path, Equals, "/user.slice")
 }

--- a/internal/buffer_pool_test.go
+++ b/internal/buffer_pool_test.go
@@ -271,6 +271,6 @@ func (s *BufferTest) TestCGroupMemory(t *C) {
                     3:freezer:/
                     2:pids:/
                     1:name=systemd:/user.slice/user-1000.slice/session-1759.scope`
-    mem_path := getMemoryCgroupPath(test_input)
+    mem_path, _ := getMemoryCgroupPath(test_input)
     t.Assert(mem_path, Equals, "/user.slice")
 }


### PR DESCRIPTION
The memory allocation logic within goofys uses HOST memory limits from the /proc/meminfo file on Linux.  This is actually the Host parameter.

In a POD word the POD memory limit via cgroup information setup.
/sys/fs/cgroup/memory{containerID}/memory.limit_in_bytes

The containerId is acquired from 
/proc/self/cpuset

But to determine if the goofys is being run in a Host based env or Docker based env
/proc/1/sched file is checked for determining if the process is init or something else.
