### PR TITLE
Expose NewGoofys in `github.com/kahing/goofys/api` package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ install:
 - mkdir /tmp/mnt
 - make
 go:
-  - 1.8.1
+  - 1.10.3

--- a/api/api.go
+++ b/api/api.go
@@ -1,7 +1,7 @@
 package goofys
 
 import (
-	. "github.com/kahing/goofys/internal"
+	"github.com/kahing/goofys/internal"
 
 	"context"
 	"fmt"
@@ -178,3 +178,21 @@ func Mount(
 
 	return
 }
+
+// expose Goofys related functions and types for extending and mounting elsewhere
+var (
+	GetStdLogger      = internal.GetStdLogger
+	InitLoggers       = internal.InitLoggers
+	MassageMountFlags = internal.MassageMountFlags
+	GetLogger         = internal.GetLogger
+	NewGoofys         = internal.NewGoofys
+	NewLogger         = internal.NewLogger
+	TryUnmount        = internal.TryUnmount
+	MyUserAndGroup    = internal.MyUserAndGroup
+)
+
+type (
+	Goofys      = internal.Goofys
+	FlagStorage = internal.FlagStorage
+	LogHandle   = internal.LogHandle
+)

--- a/internal/goofys.go
+++ b/internal/goofys.go
@@ -1157,3 +1157,15 @@ func (fs *Goofys) getMimeType(fileName string) (retMime *string) {
 
 	return
 }
+
+// return full name of the given inode
+func (fs *Goofys) GetFullName(id fuseops.InodeID) *string {
+	fs.mu.Lock()
+	inode := fs.inodes[id]
+	fs.mu.Unlock()
+	if inode == nil {
+		return nil
+	}
+	return inode.FullName()
+
+}


### PR DESCRIPTION
I'm currently extending `goofys` to add local caching for some specific use cases in which `catfs` does not serve our needs.  However, the current API of the `goofys/api` package is very limited (as it only allows you to mount).  It would be really useful to be able to create a  `goofys/internal.Goofys` struct such that certain functions of the `github.com/jacobsa/fuse/fuseutil.FileSystem` interface can be overridden; but the associated goofys functions and types are currently walled off in the `goofys/internal` package, which cannot be imported.

This PR exposes a few of the functions and types from the `internal` package that enable extending `goofys`. I also added a `GetFullName` function I've found very useful.  This PR makes no functional changes but would be awesome to have incorporated into the codebase from an extensibility standpoint.
