### PR TITLE
Add command line option to override http.Client Timeout

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -50,6 +50,7 @@ type Config struct {
 	ExplicitDir  bool
 	StatCacheTTL time.Duration
 	TypeCacheTTL time.Duration
+	HTTPTimeout  time.Duration
 
 	// Debugging
 	DebugFuse  bool
@@ -83,7 +84,7 @@ func Mount(
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 10 * time.Second,
 		},
-		Timeout: 30 * time.Second,
+		Timeout: flags.HTTPTimeout,
 	})
 
 	if len(flags.Profile) > 0 {

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -217,6 +217,11 @@ func NewApp() (app *cli.App) {
 				Usage: "How long to cache name -> file/dir mappings in directory " +
 					"inodes.",
 			},
+			cli.DurationFlag{
+				Name:  "http-timeout",
+				Value: 30 * time.Second,
+				Usage: "Set the timeout on HTTP requests to S3",
+			},
 
 			/////////////////////////
 			// Debugging
@@ -250,7 +255,7 @@ func NewApp() (app *cli.App) {
 		flagCategories[f] = "aws"
 	}
 
-	for _, f := range []string{"cheap", "no-implicit-dir", "stat-cache-ttl", "type-cache-ttl"} {
+	for _, f := range []string{"cheap", "no-implicit-dir", "stat-cache-ttl", "type-cache-ttl", "http-timeout"} {
 		flagCategories[f] = "tuning"
 	}
 
@@ -297,6 +302,7 @@ type FlagStorage struct {
 	ExplicitDir  bool
 	StatCacheTTL time.Duration
 	TypeCacheTTL time.Duration
+	HTTPTimeout  time.Duration
 
 	// Debugging
 	DebugFuse  bool
@@ -352,6 +358,7 @@ func PopulateFlags(c *cli.Context) (ret *FlagStorage) {
 		ExplicitDir:  c.Bool("no-implicit-dir"),
 		StatCacheTTL: c.Duration("stat-cache-ttl"),
 		TypeCacheTTL: c.Duration("type-cache-ttl"),
+		HTTPTimeout:  c.Duration("http-timeout"),
 
 		// S3
 		Endpoint:       c.String("endpoint"),


### PR DESCRIPTION
We use goofys to do random reads in large files stored in S3.  Most of the time, the GetObject requests to S3 are very fast - less than 100 ms.  But occasionally - about 1 in 1000 requests - it takes much longer.  Several seconds, even up to 20 seconds.  The 30 second timeout is nice, but in our case we've found that a much shorter timeout and quick retry works better for us - as low as 1 second really helped even out our response times.

I've added a command line flag `-http-timeout` to set the value, but it has the same default as the previous hard-coded value (30 seconds).  So it should behave exactly the same if you don't specify the flag.