### PR TITLE
Fix unformatted logging call

### DIFF
--- a/internal/goofys_test.go
+++ b/internal/goofys_test.go
@@ -117,7 +117,7 @@ func waitFor(t *C, addr string) (err error) {
 			conn.Close()
 			return
 		} else {
-			t.Log("Cound not connect: %v", err)
+			t.Logf("Cound not connect: %v", err)
 			time.Sleep(100 * time.Millisecond)
 		}
 	}


### PR DESCRIPTION
Addresses errors of the form:

```
internal/goofys_test.go:120: C.Log call has possible formatting
directive %v
```