### PR TITLE
Make goofys work well with automounting

### DIFF
--- a/example/test_api.go
+++ b/example/test_api.go
@@ -4,17 +4,27 @@ import (
 	goofys "github.com/kahing/goofys/api"
 
 	"fmt"
+
 	"golang.org/x/net/context"
 )
 
 func main() {
+	mountPoint := "/tmp/s3"
+	bucketName := "goofys"
+
 	config := goofys.Config{
-		MountPoint: "/tmp/s3",
+		MountPoint: mountPoint,
 		DirMode:    0755,
 		FileMode:   0644,
 	}
 
-	_, mp, err := goofys.Mount(context.Background(), "goofys", &config)
+	ready := make(chan error, 1)
+	dev, err := goofys.FuseMount(mountPoint, bucketName, &config, ready)
+	if err != nil {
+		panic(fmt.Sprintf("Unable to mount %v: %v", config.MountPoint, err))
+	}
+
+	_, mp, err := goofys.FuseServe(context.Background(), bucketName, dev, &config, ready)
 	if err != nil {
 		panic(fmt.Sprintf("Unable to mount %v: %v", config.MountPoint, err))
 	} else {


### PR DESCRIPTION
**What this patch solves**:
make goofys work well with automounting

**Issue description**:
When using goofys with e.g. x-systemd.automount:

- (a). if not in foreground mode (without "-f"), `chdir(2)` blocks because `os.Stat()` +
`fusermount(1)` calls are done in the "Reborn"-ed process, which has called
`setsid(2)`. autofs assumes the access by the reborned process as a normal autofs access, therefore `path_lookupat` leads to `autofs_write`. Being blocked before fuse fs mount is problematic because we cannot proceed to fuse fs setup itself.

- (b). if in foreground mode (with "-f"), we can reach to fuse server setups because all operations that touches autofs before fuse fs setup are done under the same PGID. But surely it does not return so mount service (which systemd autogenerated) times out. Luckily, we are probably just doing `cd` into the mountpoint, so it fails to umount it, and the fuse server servives. Therefore we get to be able to use fuse fs normally, as opposed to (a), where we cannot use it at all.

So I think we have two options without any code change.
- (1). tolerate what I described in (b)., with x-systemd.mount_timeout set to some reasonable
      value e.g., 10 seconds.
- (2). do not support systemd automount support at all 

And I chose to suggest this patch (let me say, option (3)) for more flexible goofys use.

**NOTE**
This depends on https://github.com/jacobsa/fuse/pull/46, **so CI fails untill it hopefully gets accepted**.

-----

I have not yet tested on various kinds of environments (i.e., pairs of various versions of systemd and kernel), and I think we better to introduce integration tests for them as well. I'd like some early feedback so before completing them, let me open this PR.

Please review, thanks.