### PR TITLE
Fix race condition between LookUpInode and ForgetInode

### DIFF
--- a/internal/goofys.go
+++ b/internal/goofys.go
@@ -604,8 +604,8 @@ func (fs *Goofys) LookUpInode(
 	parent := fs.getInodeOrDie(op.Parent)
 	fs.mu.Unlock()
 
-	parent.mu.Lock()
 	fs.mu.Lock()
+	parent.mu.Lock()
 	inode = parent.findChildUnlockedFull(op.Name)
 	if inode != nil {
 		ok = true
@@ -627,8 +627,8 @@ func (fs *Goofys) LookUpInode(
 	} else {
 		ok = false
 	}
-	fs.mu.Unlock()
 	parent.mu.Unlock()
+	fs.mu.Unlock()
 
 	if !ok {
 		var newInode *Inode
@@ -699,14 +699,12 @@ func (fs *Goofys) ForgetInode(
 	if stale {
 		delete(fs.inodes, op.Inode)
 		fs.forgotCnt += 1
-		fs.mu.Unlock()
 
 		if inode.Parent != nil {
 			inode.Parent.removeChild(inode)
 		}
-	} else {
-		fs.mu.Unlock()
 	}
+	fs.mu.Unlock()
 
 	return
 }

--- a/internal/goofys.go
+++ b/internal/goofys.go
@@ -650,17 +650,17 @@ func (fs *Goofys) LookUpInode(
 		}
 
 		if inode == nil {
+			fs.mu.Lock()
 			parent.mu.Lock()
 			// check again if it's there, could have been
 			// added by another lookup or readdir
 			inode = parent.findChildUnlockedFull(op.Name)
 			if inode == nil {
-				fs.mu.Lock()
 				inode = newInode
 				fs.insertInode(parent, inode)
-				fs.mu.Unlock()
 			}
 			parent.mu.Unlock()
+			fs.mu.Unlock()
 		} else {
 			if newInode.Attributes.Mtime.IsZero() {
 				newInode.Attributes.Mtime = inode.Attributes.Mtime


### PR DESCRIPTION
This pull request try to fix issue https://github.com/kahing/goofys/issues/392

```
1. ForgetInode get fs.mu.Lock()
2. LookUpInode get parent.mu.Lock()
3. ForgetInode release fs.mu.Unlock() and wait for parent.mu.Lock() in inode.Parent.removeChild(inode)
4. LookUpInode get fs.mu.Lock() then get inode
5. LookUpInode release parent.mu.Unlock()
6. inode.Parent.removeChild(inode) get parent.mu.Lock() and remove the inode
```

If I just change `ForgetInode`，which will lead to other deadlock, that is 
```
1. ForgetInode get fs.mu.Lock()
2. LookUpInode get parent.mu.Lock()
3. ForgetInode try to get parent.mu.Lock()
4. LookUpInode get fs.mu.Lock()
```

So I think `LookUpInode` also needs change order of lock. But I'm not familiar with goofys, please help review it. 

Thank you very much!