### PR TITLE
Add --use-vhost option to enable S3 virtual-hosted–style

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -34,18 +34,19 @@ type Config struct {
 	Gid      uint32
 
 	// S3
-	Endpoint       string
-	Region         string
-	RegionSet      bool
-	StorageClass   string
-	AccessKey      string
-	SecretKey      string
-	Profile        string
-	UseContentType bool
-	UseSSE         bool
-	UseKMS         bool
-	KMSKeyID       string
-	ACL            string
+	Endpoint            string
+	Region              string
+	RegionSet           bool
+	StorageClass        string
+	AccessKey           string
+	SecretKey           string
+	Profile             string
+	UseContentType      bool
+	UseSSE              bool
+	UseKMS              bool
+	KMSKeyID            string
+	ACL                 string
+	UseVirtualHostStyle bool
 
 	// Tuning
 	Cheap        bool
@@ -99,7 +100,7 @@ func Mount(
 		awsConfig.Endpoint = &flags.Endpoint
 	}
 
-	awsConfig.S3ForcePathStyle = aws.Bool(true)
+	awsConfig.S3ForcePathStyle = aws.Bool(!flags.UseVirtualHostStyle)
 
 	fs = NewGoofys(ctx, bucketName, awsConfig, &flags)
 	if fs == nil {

--- a/internal/aws_test.go
+++ b/internal/aws_test.go
@@ -35,9 +35,11 @@ func (s *AwsTest) SetUpSuite(t *C) {
 		S3ForcePathStyle: aws.Bool(true),
 	}
 
+	flags := &FlagStorage{}
 	s.fs = &Goofys{
 		awsConfig: awsConfig,
 		sess:      session.New(awsConfig),
+		flags:     flags,
 	}
 
 	s.fs.s3 = s.fs.newS3()

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -191,6 +191,11 @@ func NewApp() (app *cli.App) {
 				Value: "",
 			},
 
+			cli.BoolFlag{
+				Name:  "use-vhost",
+				Usage: "Enable S3 virtual-hosted–style",
+			},
+
 			/////////////////////////
 			// Tuning
 			/////////////////////////
@@ -286,16 +291,17 @@ type FlagStorage struct {
 	Gid      uint32
 
 	// S3
-	Endpoint       string
-	Region         string
-	RegionSet      bool
-	StorageClass   string
-	Profile        string
-	UseContentType bool
-	UseSSE         bool
-	UseKMS         bool
-	KMSKeyID       string
-	ACL            string
+	Endpoint            string
+	Region              string
+	RegionSet           bool
+	StorageClass        string
+	Profile             string
+	UseContentType      bool
+	UseSSE              bool
+	UseKMS              bool
+	KMSKeyID            string
+	ACL                 string
+	UseVirtualHostStyle bool
 
 	// Tuning
 	Cheap        bool
@@ -361,16 +367,17 @@ func PopulateFlags(c *cli.Context) (ret *FlagStorage) {
 		HTTPTimeout:  c.Duration("http-timeout"),
 
 		// S3
-		Endpoint:       c.String("endpoint"),
-		Region:         c.String("region"),
-		RegionSet:      c.IsSet("region"),
-		StorageClass:   c.String("storage-class"),
-		Profile:        c.String("profile"),
-		UseContentType: c.Bool("use-content-type"),
-		UseSSE:         c.Bool("sse"),
-		UseKMS:         c.IsSet("sse-kms"),
-		KMSKeyID:       c.String("sse-kms"),
-		ACL:            c.String("acl"),
+		Endpoint:            c.String("endpoint"),
+		Region:              c.String("region"),
+		RegionSet:           c.IsSet("region"),
+		StorageClass:        c.String("storage-class"),
+		Profile:             c.String("profile"),
+		UseContentType:      c.Bool("use-content-type"),
+		UseSSE:              c.Bool("sse"),
+		UseKMS:              c.IsSet("sse-kms"),
+		KMSKeyID:            c.String("sse-kms"),
+		ACL:                 c.String("acl"),
+		UseVirtualHostStyle: c.Bool("use-vhost"),
 
 		// Debugging,
 		DebugFuse:  c.Bool("debug_fuse"),

--- a/internal/goofys.go
+++ b/internal/goofys.go
@@ -304,6 +304,12 @@ func (fs *Goofys) detectBucketLocationByHEAD() (err error, isAws bool) {
 		u.Host = endpoint.Host
 	}
 
+	if fs.flags.UseVirtualHostStyle {
+		u.Host = fmt.Sprintf("%s.%s", fs.bucket, u.Host)
+		u.Path = ""
+		s3Log.Debugf("Use vhost style: %v", u.String())
+	}
+
 	var req *http.Request
 	var resp *http.Response
 


### PR DESCRIPTION
I want to use virtual hosted style since a proxy server only support virtual hosted style in my environment.

refer to https://github.com/kahing/goofys/pull/351#issuecomment-418610769

Originally, this patch came from @zhenlingcn (#351), so I hope he/she will update the patch and it will be merged. if so, this PR would be closed.