### PR TITLE
list gridscale among tested providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ goofys has been tested with the following non-AWS providers:
 * DreamObjects (Ceph)
 * EMC Atmos
 * Google Cloud Storage
+* gridscale Object Storage (Ceph)
 * OpenStack Swift
 * S3Proxy
 * Minio (limited)


### PR DESCRIPTION
I just tested our (gridscale) object storage with goofys and it works just fine.