### PR TITLE
Add the generation of inode number based on the file path.

### DIFF
--- a/internal/utils.go
+++ b/internal/utils.go
@@ -20,6 +20,8 @@ import (
 	"unicode"
 
 	"github.com/jacobsa/fuse"
+
+	"hash/fnv"
 )
 
 func MaxInt(a, b int) int {
@@ -100,4 +102,10 @@ func TryUnmount(mountPoint string) (err error) {
 		}
 	}
 	return
+}
+
+func makeInodeID(path string) uint64 {
+	hash := fnv.New64a()
+	hash.Write([]byte(path))
+	return hash.Sum64()
 }


### PR DESCRIPTION
Pretend we have a filesystem.

/a
/a/b
/a/c
/a/d

/a will always be inode 1
If I access /a/b second, it will have inode 2
If I access /a/c second, it will have inode 2
and so on.

Now it generates unique ID for this mount point that based on file path.