### PR TITLE
Use the default credentials chain to when loading a shared AWS config

### DIFF
--- a/api/common/conf_s3.go
+++ b/api/common/conf_s3.go
@@ -113,6 +113,9 @@ func (c *S3Config) ToAwsConfig(flags *FlagStorage) (*aws.Config, error) {
 			if err != nil {
 				return nil, err
 			}
+			// Creating a new session from the shared config allows the
+			// default credentials chain to get resolve a provider
+			c.Credentials = s3Session.Config.Credentials
 		}
 		c.Session = s3Session
 	}


### PR DESCRIPTION
This change allows the shared config to resolve a usable credentials provider by leveraging the SDK's default credentials chain.

With this change I could drop my previous PR (#420)