### PR TITLE
Removed selecting storage backend by URL-scheme.

### DIFF
--- a/api/common/config.go
+++ b/api/common/config.go
@@ -37,10 +37,10 @@ type FlagStorage struct {
 	Gid      uint32
 
 	// Common Backend Config
-	UseContentType bool
+	BackendConfig  interface{}
+	Backend        string
 	Endpoint       string
-
-	Backend interface{}
+	UseContentType bool
 
 	// Tuning
 	Cheap        bool
@@ -53,6 +53,18 @@ type FlagStorage struct {
 	DebugFuse  bool
 	DebugS3    bool
 	Foreground bool
+
+	// S3
+	Region        string
+	RegionSet     bool
+	RequesterPays bool
+	StorageClass  string
+	Profile       string
+	UseSSE        bool
+	UseKMS        bool
+	KMSKeyID      string
+	ACL           string
+	Subdomain     bool
 }
 
 func (flags *FlagStorage) GetMimeType(fileName string) (retMime *string) {

--- a/doc/backends/azure-blob-storage.md
+++ b/doc/backends/azure-blob-storage.md
@@ -1,0 +1,49 @@
+### Goofys with Azure Blob Storage
+
+Goofys is already can work with Azure Blob Storage out of the box.
+To achive successful mount of azblob container to your fs, you need to follow next simple steps:
+
+- Get account name and blob container name from your Azure Portal
+- Get the Access key for your account from Azure Portal like described [here](https://help.bittitan.com/hc/en-us/articles/115008109327-How-do-I-get-an-access-key-for-Azure-Blob-storage- "here").
+- You can put account and key values to the config file like this:
+
+```ini
+[storage]
+account = "myblobstorage"
+key = "TZR0DqSYXTVLJRoWUlHnd80qrMJTUW2nBlv1kfaz6gG13OjZpQtKt6GvpgY8JrYsKAUxbWHTHc4KU4Wps5IhYy=="
+```
+And put the file here: ~/.azure/config
+Or instead of this step you can make sure that your shell has these environment variables set before starting goofys:
+
+```sh
+export AZURE_STORAGE_ACCOUNT="yblobstorage"
+export AZURE_STORAGE_ACCESS_KEY="ZR0DqSYXTVLJRoWUlHnd80qrMJTUW2nBlv1kfaz6gG13OjZpQtKt6GvpgY8JrYsKAUxbWHTHc4KU4Wps5IhYy=="
+```
+- Install azure-cli using [this instruction](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest "this instruction").
+- Use azure-cli to authenticate:
+
+```bash
+# login first
+az login
+
+# list all subscribtions and select the needed one
+az account list
+
+# select current subscription (get its id from previous step)
+az account set --subscription <name or id>
+
+# write auth data to our azure folder (can take several minutes)
+az ad sp create-for-rbac --sdk-auth > ~/.azure/auth
+```
+- Add path to auth file to AZURE_AUTH_LOCATION env variable:
+
+``` bash
+export AZURE_AUTH_LOCATION="~/.azure/auth"
+```
+- Now we have all necessary info to start the goofys:
+
+```bash
+goofys --storage-backend azure-blob-storage <container-name> path/to/mount
+```
+
+Now everything should work.

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -107,6 +107,12 @@ func NewApp() (app *cli.App) {
 			},
 
 			cli.StringFlag{
+				Name: "storage-backend",
+				Usage: "Select storage backend: s3, azure-blob-storage, " +
+					"azure-data-lake. (default: s3)",
+			},
+
+			cli.StringFlag{
 				Name: "cache",
 				Usage: "Directory to use for data cache. " +
 					"Requires catfs and `-o allow_other'. " +
@@ -328,6 +334,7 @@ func PopulateFlags(c *cli.Context) (ret *FlagStorage) {
 		HTTPTimeout:  c.Duration("http-timeout"),
 
 		// Common Backend Config
+		Backend:        c.String("storage-backend"),
 		Endpoint:       c.String("endpoint"),
 		UseContentType: c.Bool("use-content-type"),
 
@@ -335,6 +342,22 @@ func PopulateFlags(c *cli.Context) (ret *FlagStorage) {
 		DebugFuse:  c.Bool("debug_fuse"),
 		DebugS3:    c.Bool("debug_s3"),
 		Foreground: c.Bool("f"),
+
+		// S3
+		Region:        c.String("region"),
+		RegionSet:     c.IsSet("region"),
+		RequesterPays: c.Bool("requester-pays"),
+		StorageClass:  c.String("storage-class"),
+		Profile:       c.String("profile"),
+		UseSSE:        c.Bool("sse"),
+		UseKMS:        c.IsSet("sse-kms"),
+		KMSKeyID:      c.String("sse-kms"),
+		ACL:           c.String("acl"),
+		Subdomain:     c.Bool("subdomain"),
+	}
+
+	if flags.Backend == "" {
+		flags.Backend = "s3"
 	}
 
 	// S3
@@ -342,10 +365,10 @@ func PopulateFlags(c *cli.Context) (ret *FlagStorage) {
 		c.IsSet("profile") || c.IsSet("sse") || c.IsSet("sse-kms") ||
 		c.IsSet("acl") || c.IsSet("subdomain") {
 
-		if flags.Backend == nil {
-			flags.Backend = (&S3Config{}).Init()
+		if flags.BackendConfig == nil {
+			flags.BackendConfig = (&S3Config{}).Init()
 		}
-		config, _ := flags.Backend.(*S3Config)
+		config, _ := flags.BackendConfig.(*S3Config)
 
 		config.Region = c.String("region")
 		config.RegionSet = c.IsSet("region")

--- a/internal/goofys_test.go
+++ b/internal/goofys_test.go
@@ -293,7 +293,7 @@ func (s *GoofysTest) SetUpTest(t *C) {
 		s.waitForEmulator(t)
 
 		conf := s.selectTestConfig(t, flags)
-		flags.Backend = &conf
+		flags.BackendConfig = &conf
 
 		s3 := NewS3(bucket, flags, &conf)
 		s.cloud = s3
@@ -309,7 +309,7 @@ func (s *GoofysTest) SetUpTest(t *C) {
 
 	} else if cloud == "gcs" {
 		conf := s.selectTestConfig(t, flags)
-		flags.Backend = &conf
+		flags.BackendConfig = &conf
 
 		s.cloud = NewGCS3(bucket, flags, &conf)
 		t.Assert(s.cloud, NotNil)
@@ -359,7 +359,7 @@ func (s *GoofysTest) SetUpTest(t *C) {
 			}
 		}
 
-		flags.Backend = &config
+		flags.BackendConfig = &config
 
 		s.cloud, err = NewAZBlob(bucket, &config)
 		t.Assert(err, IsNil)
@@ -378,7 +378,7 @@ func (s *GoofysTest) SetUpTest(t *C) {
 		}
 		config.Init()
 
-		flags.Backend = &config
+		flags.BackendConfig = &config
 
 		s.cloud, err = NewADLv1(bucket, flags, &config)
 		t.Assert(err, IsNil)
@@ -2601,7 +2601,7 @@ func (s *GoofysTest) newBackend(t *C, bucket string, createBucket bool) (cloud S
 	var err error
 	switch s.cloud.(type) {
 	case *S3Backend:
-		config, _ := s.fs.flags.Backend.(*S3Config)
+		config, _ := s.fs.flags.BackendConfig.(*S3Config)
 		cloud = NewS3(bucket, s.fs.flags, config)
 		if s3, ok := cloud.(*S3Backend); ok {
 			s3.aws = hasEnv("AWS")
@@ -2613,15 +2613,15 @@ func (s *GoofysTest) newBackend(t *C, bucket string, createBucket bool) (cloud S
 			}
 		}
 	case *GCS3:
-		config, _ := s.fs.flags.Backend.(*S3Config)
+		config, _ := s.fs.flags.BackendConfig.(*S3Config)
 		cloud = NewGCS3(bucket, s.fs.flags, config)
 		t.Assert(err, IsNil)
 	case *AZBlob:
-		config, _ := s.fs.flags.Backend.(*AZBlobConfig)
+		config, _ := s.fs.flags.BackendConfig.(*AZBlobConfig)
 		cloud, err = NewAZBlob(bucket, config)
 		t.Assert(err, IsNil)
 	case *ADLv1:
-		config, _ := s.fs.flags.Backend.(*ADLv1Config)
+		config, _ := s.fs.flags.BackendConfig.(*ADLv1Config)
 		cloud, err = NewADLv1(bucket, s.fs.flags, config)
 		t.Assert(err, IsNil)
 	default:

--- a/internal/minio_test.go
+++ b/internal/minio_test.go
@@ -39,8 +39,8 @@ func (s *MinioTest) SetUpSuite(t *C) {
 		SecretKey: "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG",
 	}).Init()
 	s.flags = FlagStorage{
-		Endpoint: "https://play.minio.io:9000",
-		Backend:  conf,
+		Endpoint:      "https://play.minio.io:9000",
+		BackendConfig: conf,
 	}
 
 	s.s3 = NewS3("", &s.flags, conf)


### PR DESCRIPTION
Removed selecting storage backend by URL-scheme. 
Added flag for selecting storage backend.

The reason of this changes is that URL-scheme backend detecting logic was working incorrect. 

To detect correct storage backend URL-scheme is used. So on `wasb://` I will have azure blob storage, on `s3://` I will have S3 Bucket etc.

Azure Blob Storage has next wasb request format: `wasb://mycontainer@myaccount.blob.core.windows.net`
If I pass bucket of such format, goofys parses myaccountblob.core.windows.net as bucket name, because it is specified as a host in the url. So goofys expects something like `wasb://mycontainer` to work correct, but that is not valid wasb url, because container is a part of userinfo, not the host.

On the other hand, to work with s3 we can specify no scheme, just bucket name and it will work.
The best way is to bring these methods to the same format - only bucket names without urls, just specify backend implicitly.

So I propose add --storage-backend flag to choose between s3 bucket, azure blob storage and data lake.