### PR TITLE
Get *resp.ContentLength error, when dir is deep.

### DIFF
--- a/internal/backend_s3.go
+++ b/internal/backend_s3.go
@@ -365,12 +365,20 @@ func (s *S3Backend) HeadBlob(param *HeadBlobInput) (*HeadBlobOutput, error) {
 	if err != nil {
 		return nil, mapAwsError(err)
 	}
+	
+	var tmpSize unit64
+	if resp.ContentLength == nil {
+		tmpSize = 4096
+	} else {
+		tmpSize = uint64(*resp.ContentLength)
+	}
+
 	return &HeadBlobOutput{
 		BlobItemOutput: BlobItemOutput{
 			Key:          &param.Key,
 			ETag:         resp.ETag,
 			LastModified: resp.LastModified,
-			Size:         uint64(*resp.ContentLength),
+			Size:         tmpSize,
 			StorageClass: resp.StorageClass,
 		},
 		ContentType: resp.ContentType,


### PR DESCRIPTION
When object is like /a/b/c/d... .Use command “cd MOUNT_DIR/a/b/c” while return an empty Content-Length. Get *resp.ContentLength will be error.
ceph version is 12.2.10.