### PR TITLE
Add Scaleway to list of compatible non-AWS S3 providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ goofys has been tested with the following non-AWS S3 providers:
 * Minio (limited)
 * OpenStack Swift
 * S3Proxy
-* Wasabi
 * Scaleway
+* Wasabi
 
 Additionally, goofys also works with the following non-S3 object stores:
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ goofys has been tested with the following non-AWS S3 providers:
 * OpenStack Swift
 * S3Proxy
 * Wasabi
+* Scaleway
 
 Additionally, goofys also works with the following non-S3 object stores:
 


### PR DESCRIPTION
Can confirm it works great 👍