### PR TITLE
Add pid file support

### DIFF
--- a/api/common/config.go
+++ b/api/common/config.go
@@ -26,6 +26,8 @@ import (
 )
 
 type FlagStorage struct {
+	PidFile string
+
 	// File system
 	MountOptions      map[string]string
 	MountPoint        string

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -97,6 +97,11 @@ func NewApp() (app *cli.App) {
 				Usage: "Print this help text and exit successfully.",
 			},
 
+			cli.StringFlag{
+				Name:  "pid-file",
+				Usage: "Write a pid file containing the process pid.",
+			},
+
 			/////////////////////////
 			// File system
 			/////////////////////////
@@ -319,6 +324,8 @@ func parseOptions(m map[string]string, s string) {
 // variables into which the flags will parse.
 func PopulateFlags(c *cli.Context) (ret *FlagStorage) {
 	flags := &FlagStorage{
+		PidFile: c.String("pid-file"),
+
 		// File system
 		MountOptions: make(map[string]string),
 		DirMode:      os.FileMode(c.Int("dir-mode")),

--- a/main.go
+++ b/main.go
@@ -16,6 +16,9 @@
 package main
 
 import (
+	"io/ioutil"
+	"strconv"
+
 	goofys "github.com/kahing/goofys/api"
 	. "github.com/kahing/goofys/api/common"
 	. "github.com/kahing/goofys/internal"
@@ -220,6 +223,15 @@ func main() {
 				kill(os.Getppid(), syscall.SIGUSR1)
 			}
 			log.Println("File system has been successfully mounted.")
+
+			if flags.PidFile != "" {
+				// Write out a Pid file
+				err = ioutil.WriteFile(flags.PidFile, []byte(strconv.Itoa(os.Getpid())), 0644)
+				if err != nil {
+					log.Fatalf("Error writing pid file: %v", err)
+				}
+			}
+
 			// Let the user unmount with Ctrl-C
 			// (SIGINT). But if cache is on, catfs will
 			// receive the signal and we would detect that exiting


### PR DESCRIPTION
This PR adds support for writing a PID file. This lets us clean up our Kubernetes flexvol mounts (https://github.com/StatCan/s3-fuse-flex-volume) since we can track the pid of the goofys instance we launch.