### PR TITLE
Memory optimization when using aws s3 (Try 2)

### DIFF
--- a/internal/handles.go
+++ b/internal/handles.go
@@ -105,28 +105,48 @@ func NewInode(fs *Goofys, parent *Inode, name *string) (inode *Inode) {
 	return
 }
 
+func deepCopyBlobItemOputput(item *BlobItemOutput) BlobItemOutput {
+
+	key := *item.Key
+	etag := *item.ETag
+	lastmodified := *item.LastModified
+	var sc string
+	if item.StorageClass != nil {
+		sc = *item.StorageClass
+	}
+
+	return BlobItemOutput{
+		Key:          &key,
+		ETag:         &etag,
+		LastModified: &lastmodified,
+		Size:         item.Size,
+		StorageClass: &sc,
+	}
+}
+
 func (inode *Inode) SetFromBlobItem(item *BlobItemOutput) {
+	itemcopy := deepCopyBlobItemOputput(item)
 	inode.mu.Lock()
 	defer inode.mu.Unlock()
 
-	inode.Attributes.Size = item.Size
+	inode.Attributes.Size = itemcopy.Size
 	// don't want to point to the attribute because that
 	// can get updated
-	size := item.Size
+	size := inode.Attributes.Size
 	inode.KnownSize = &size
 	if item.LastModified != nil {
-		inode.Attributes.Mtime = *item.LastModified
+		inode.Attributes.Mtime = *itemcopy.LastModified
 	} else {
 		inode.Attributes.Mtime = inode.fs.rootAttrs.Mtime
 	}
 	if item.ETag != nil {
-		inode.s3Metadata["etag"] = []byte(*item.ETag)
-		inode.knownETag = item.ETag
+		inode.s3Metadata["etag"] = []byte(*itemcopy.ETag)
+		inode.knownETag = itemcopy.ETag
 	} else {
 		delete(inode.s3Metadata, "etag")
 	}
 	if item.StorageClass != nil {
-		inode.s3Metadata["storage-class"] = []byte(*item.StorageClass)
+		inode.s3Metadata["storage-class"] = []byte(*itemcopy.StorageClass)
 	} else {
 		delete(inode.s3Metadata, "storage-class")
 	}


### PR DESCRIPTION
The changes here make it so that there are no longer references being
held to the s3 objects allocated during XMLToStruct in the s3 libraries.

In my testing, when doing a listObjectsV2 against ~383,000 objects, this
change saves about 1/2 of the memory uses. (1gb of use without these
changes and ~500mb with them)

This is an updated way of doing this. I somehow closed out https://github.com/kahing/goofys/pull/547 and can't reopen the PR.