### PR TITLE
Add GetFullName() back

### DIFF
--- a/internal/goofys.go
+++ b/internal/goofys.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"net/http"
 	"net/url"
 	"runtime/debug"
 	"strings"
@@ -35,7 +36,6 @@ import (
 	"github.com/jacobsa/fuse/fuseutil"
 
 	"github.com/sirupsen/logrus"
-	"net/http"
 )
 
 // goofys is a Filey System written in Go. All the backend data is
@@ -1194,4 +1194,16 @@ func (fs *Goofys) Rename(
 		}
 	}
 	return
+}
+
+// return full name of the given inode
+func (fs *Goofys) GetFullName(id fuseops.InodeID) *string {
+	fs.mu.Lock()
+	inode := fs.inodes[id]
+	fs.mu.Unlock()
+	if inode == nil {
+		return nil
+	}
+	return inode.FullName()
+
 }


### PR DESCRIPTION
This is effectively the same PR as https://github.com/kahing/goofys/pull/330 which was merged back in 2018 and allowed us at Spell to wrap `goofys` into a `goofyscache` library that solves our specific use cases that `catfs` does not.

We are currently live on an old version of goofys, but would like to take advantage of the recently added Azure support and in order to upgrade we need the `GetFullName()` method to be added back.

Thanks!