### PR TITLE
Escape the special char in name correctly.  As per the AWS documentat…

### DIFF
--- a/internal/backend_s3.go
+++ b/internal/backend_s3.go
@@ -475,7 +475,7 @@ func (s *S3Backend) mpuCopyPart(from string, to string, mpuId string, bytes stri
 	params := &s3.UploadPartCopyInput{
 		Bucket:            &s.bucket,
 		Key:               &to,
-		CopySource:        aws.String(pathEscape(from)),
+		CopySource:        aws.String(url.QueryEscape(from)),
 		UploadId:          &mpuId,
 		CopySourceRange:   &bytes,
 		CopySourceIfMatch: srcEtag,
@@ -667,7 +667,7 @@ func (s *S3Backend) CopyBlob(param *CopyBlobInput) (*CopyBlobOutput, error) {
 
 	params := &s3.CopyObjectInput{
 		Bucket:            &s.bucket,
-		CopySource:        aws.String(pathEscape(from)),
+		CopySource:        aws.String(url.QueryEscape(from)),
 		Key:               &param.Destination,
 		StorageClass:      param.StorageClass,
 		ContentType:       s.flags.GetMimeType(param.Destination),

--- a/internal/goofys.go
+++ b/internal/goofys.go
@@ -571,13 +571,6 @@ func mapAwsError(err error) error {
 	}
 }
 
-// note that this is NOT the same as url.PathEscape in golang 1.8,
-// as this preserves / and url.PathEscape converts / to %2F
-func pathEscape(path string) string {
-	u := url.URL{Path: path}
-	return u.EscapedPath()
-}
-
 func (fs *Goofys) allocateInodeId() (id fuseops.InodeID) {
 	id = fs.nextInodeID
 	fs.nextInodeID++

--- a/internal/goofys_test.go
+++ b/internal/goofys_test.go
@@ -985,6 +985,32 @@ func (s *GoofysTest) TestCreateFiles(t *C) {
 	defer resp.Body.Close()
 }
 
+func (s *GoofysTest) TestRenameWithSpecialChar(t *C) {
+	fileName := "foo+"
+	s.testWriteFile(t, fileName, 1, 128*1024)
+
+	inode, err := s.getRoot(t).LookUp(fileName)
+	t.Assert(err, IsNil)
+
+	fh, err := inode.OpenFile(fuseops.OpMetadata{uint32(os.Getpid())})
+	t.Assert(err, IsNil)
+
+	err = fh.FlushFile()
+	t.Assert(err, IsNil)
+
+	resp, err := s.cloud.GetBlob(&GetBlobInput{Key: fileName})
+	t.Assert(err, IsNil)
+	// ADLv1 doesn't return size when we do a GET
+	if _, adlv1 := s.cloud.(*ADLv1); !adlv1 {
+		t.Assert(resp.HeadBlobOutput.Size, Equals, uint64(1))
+	}
+	defer resp.Body.Close()
+
+	root := s.getRoot(t)
+	err = root.Rename(fileName, root, "foo")
+	t.Assert(err, IsNil)
+}
+
 func (s *GoofysTest) TestUnlink(t *C) {
 	fileName := "file1"
 


### PR DESCRIPTION
Escape the special char in name correctly.  As per the AWS documentation, CopyRequest is sending request param and it advised to URLEncode the source name.  Using the `url.QueryEscape` to encode the name instead of `url.PahEscape` since it does not cover all special char.