### PR TITLE
Add --no-default-permissions flag based on latest fuse library.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,7 +15,8 @@
 	url = https://github.com/jtolds/gls
 [submodule "vendor/github.com/jacobsa/fuse"]
 	path = vendor/github.com/jacobsa/fuse
-	url = https://github.com/kahing/fusego
+	url = https://github.com/jacobsa/fuse
+	branch = master
 [submodule "vendor/github.com/Azure/go-autorest"]
 	path = vendor/github.com/Azure/go-autorest
 	url = https://github.com/Azure/go-autorest/

--- a/api/api.go
+++ b/api/api.go
@@ -27,10 +27,11 @@ func Mount(
 	}
 	// Mount the file system.
 	mountCfg := &fuse.MountConfig{
-		FSName:                  bucketName,
-		Options:                 flags.MountOptions,
-		ErrorLogger:             GetStdLogger(NewLogger("fuse"), logrus.ErrorLevel),
-		DisableWritebackCaching: true,
+		FSName:                    bucketName,
+		Options:                   flags.MountOptions,
+		ErrorLogger:               GetStdLogger(NewLogger("fuse"), logrus.ErrorLevel),
+		DisableWritebackCaching:   true,
+		DisableDefaultPermissions: flags.DisableDefaultPermissions,
 	}
 
 	if flags.DebugFuse {

--- a/api/common/config.go
+++ b/api/common/config.go
@@ -45,11 +45,12 @@ type FlagStorage struct {
 	Backend interface{}
 
 	// Tuning
-	Cheap        bool
-	ExplicitDir  bool
-	StatCacheTTL time.Duration
-	TypeCacheTTL time.Duration
-	HTTPTimeout  time.Duration
+	Cheap                     bool
+	ExplicitDir               bool
+	StatCacheTTL              time.Duration
+	TypeCacheTTL              time.Duration
+	HTTPTimeout               time.Duration
+	DisableDefaultPermissions bool
 
 	// Debugging
 	DebugFuse  bool

--- a/internal/dir.go
+++ b/internal/dir.go
@@ -899,7 +899,7 @@ func (parent *Inode) Unlink(name string) (err error) {
 }
 
 func (parent *Inode) Create(
-	name string, metadata fuseops.OpMetadata) (inode *Inode, fh *FileHandle) {
+	name string, metadata fuseops.OpContext) (inode *Inode, fh *FileHandle) {
 
 	parent.logFuse("Create", name)
 

--- a/internal/file.go
+++ b/internal/file.go
@@ -71,7 +71,7 @@ const READAHEAD_CHUNK = uint32(20 * 1024 * 1024)
 
 // NewFileHandle returns a new file handle for the given `inode` triggered by fuse
 // operation with the given `opMetadata`
-func NewFileHandle(inode *Inode, opMetadata fuseops.OpMetadata) *FileHandle {
+func NewFileHandle(inode *Inode, opMetadata fuseops.OpContext) *FileHandle {
 	tgid, err := GetTgid(opMetadata.Pid)
 	if err != nil {
 		log.Debugf(

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -242,6 +242,10 @@ func NewApp() (app *cli.App) {
 				Value: 30 * time.Second,
 				Usage: "Set the timeout on HTTP requests to S3",
 			},
+			cli.BoolFlag{
+				Name:  "disable-default-permissions",
+				Usage: "Disable UNIX default_permissions flag on FUSE mount.",
+			},
 
 			/////////////////////////
 			// Debugging
@@ -275,7 +279,7 @@ func NewApp() (app *cli.App) {
 		flagCategories[f] = "aws"
 	}
 
-	for _, f := range []string{"cheap", "no-implicit-dir", "stat-cache-ttl", "type-cache-ttl", "http-timeout"} {
+	for _, f := range []string{"cheap", "no-implicit-dir", "stat-cache-ttl", "type-cache-ttl", "http-timeout", "disable-default-permissions"} {
 		flagCategories[f] = "tuning"
 	}
 
@@ -327,11 +331,12 @@ func PopulateFlags(c *cli.Context) (ret *FlagStorage) {
 		Gid:          uint32(c.Int("gid")),
 
 		// Tuning,
-		Cheap:        c.Bool("cheap"),
-		ExplicitDir:  c.Bool("no-implicit-dir"),
-		StatCacheTTL: c.Duration("stat-cache-ttl"),
-		TypeCacheTTL: c.Duration("type-cache-ttl"),
-		HTTPTimeout:  c.Duration("http-timeout"),
+		Cheap:                     c.Bool("cheap"),
+		ExplicitDir:               c.Bool("no-implicit-dir"),
+		StatCacheTTL:              c.Duration("stat-cache-ttl"),
+		TypeCacheTTL:              c.Duration("type-cache-ttl"),
+		HTTPTimeout:               c.Duration("http-timeout"),
+		DisableDefaultPermissions: c.Bool("disable-default-permissions"),
 
 		// Common Backend Config
 		Endpoint:       c.String("endpoint"),

--- a/internal/goofys.go
+++ b/internal/goofys.go
@@ -880,7 +880,7 @@ func (fs *Goofys) OpenFile(
 	in := fs.getInodeOrDie(op.Inode)
 	fs.mu.RUnlock()
 
-	fh, err := in.OpenFile(op.Metadata)
+	fh, err := in.OpenFile(op.OpContext)
 	if err != nil {
 		return
 	}
@@ -953,10 +953,10 @@ func (fs *Goofys) FlushFile(
 	// This check helps us with scenarios like https://github.com/kahing/goofys/issues/273
 	// Also see goofys_test.go:TestClientForkExec.
 	if fh.Tgid != nil {
-		tgid, err := GetTgid(op.Metadata.Pid)
+		tgid, err := GetTgid(op.OpContext.Pid)
 		if err != nil {
 			fh.inode.logFuse("<-- FlushFile",
-				fmt.Sprintf("Failed to retrieve tgid from op.Metadata.Pid. FlushFileOp:%#v, err:%v",
+				fmt.Sprintf("Failed to retrieve tgid from op.OpContext.Pid. FlushFileOp:%#v, err:%v",
 					op, err))
 			return fuse.EIO
 		}
@@ -1013,7 +1013,7 @@ func (fs *Goofys) CreateFile(
 	parent := fs.getInodeOrDie(op.Parent)
 	fs.mu.RUnlock()
 
-	inode, fh := parent.Create(op.Name, op.Metadata)
+	inode, fh := parent.Create(op.Name, op.OpContext)
 
 	parent.mu.Lock()
 

--- a/internal/handles.go
+++ b/internal/handles.go
@@ -494,7 +494,7 @@ func (inode *Inode) ListXattr() ([]string, error) {
 	return xattrs, nil
 }
 
-func (inode *Inode) OpenFile(metadata fuseops.OpMetadata) (fh *FileHandle, err error) {
+func (inode *Inode) OpenFile(metadata fuseops.OpContext) (fh *FileHandle, err error) {
 	inode.logFuse("OpenFile")
 
 	inode.mu.Lock()


### PR DESCRIPTION
As per #590.

This also includes an updated `fuse` library which had some mandatory changes to elsewhere in the codebase.