### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ configured for `root`, and can add this to `/etc/fstab`:
 goofys#bucket   /mnt/mountpoint        fuse     _netdev,allow_other,--file-mode=0666,--dir-mode=0777    0       0
 ```
 
+Requires fuse, check command fusermount -V, on some distributions package needs to be installed.
+
 See also: [Instruction for Azure Blob Storage, Azure Data Lake Gen1, and Azure Data Lake Gen2](https://github.com/kahing/goofys/blob/master/README-azure.md).
 
 Got more questions? Check out [questions other people asked](https://github.com/kahing/goofys/issues?utf8=%E2%9C%93&q=is%3Aissue%20label%3Aquestion%20)


### PR DESCRIPTION
Hi, I suggest to mention that for mounting via /etc/fstab fuse needs to be installed. It can be tested via checking for the fuse version: fusermount -V. On my Centos 7.9 sudo yum install -y fuse was needed.