### PR TITLE
Add updated cask installation method for brew

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ close-to-open.
 * On macOS, install via [Homebrew](https://brew.sh/):
 
 ```ShellSession
-$ brew cask install osxfuse
+$ brew install --cask osxfuse
 $ brew install goofys
 ```
 


### PR DESCRIPTION
As of Homebrew 3.1.2, `cask` CLI  invocation syntax has changed. 

Previous syntax: 
```brew cask install <cask-package>
``` 
New syntax:
```brew install --cask <cask-package>
```

I've updated the README.md to reflect this change.