### PR TITLE
Allow to configure a value of maximum retry attempts

### DIFF
--- a/internal/backend_s3.go
+++ b/internal/backend_s3.go
@@ -151,7 +151,7 @@ func (s *S3Backend) detectBucketLocationByHEAD() (err error, isAws bool) {
 		return
 	}
 
-	allowFails := 3
+	allowFails := s.config.MaxRetries
 	for i := 0; i < allowFails; i++ {
 		resp, err = http.DefaultTransport.RoundTrip(req)
 		if err != nil {


### PR DESCRIPTION
### Description
At the current implementation it is not possible to set the AWS [max_attempts](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-config-max_attempts) variable, and the default value is always use. On some scenarios with high concurrency the default value is too low and many errors arise. 

At this pull request, if the environment variable `AWS_MAX_ATTEMPTS` is defined it will be use instead of the default value. This allows to increase the retries and then Goofys can handle this high concurrent scenarios without any problem.  