### PR TITLE
📚 Add note on the correct package name required to mount on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ close-to-open.
 
 # Installation
 
-* On Linux, install via [pre-built binaries](https://github.com/kahing/goofys/releases/latest/download/goofys). You may also need to install fuse-utils first.
+* On Linux, install via [pre-built binaries](https://github.com/kahing/goofys/releases/latest/download/goofys). 
+You may also need to install fuse too if you want to mount it on startup.
 
 * On macOS, install via [Homebrew](https://brew.sh/):
 


### PR DESCRIPTION
I've spent a few hours navigating goofy's issues and getting `2021-06-16T17:11:03.392028+00:00 ip-10-10-73-45 kernel: [   9.551179] fuse: Unknown parameter '--file-mode` when following the README instructions to mount on startup.

The suggested package `fuse-utils` was not found on `Ubuntu 20.04.2 LTS` mirros, but installing fuse with `sudo apt install fuse` worked and the bucket is now mounted on startup.

Let me know if you want the message rephrased clarifying the ubuntu version


Thank you for your awesome work maintaining the lib!
