### PR TITLE
Add linode to tested non-AWS S3 providers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ goofys has been tested with the following non-AWS S3 providers:
 * EdgeFS
 * EMC Atmos
 * Google Cloud Storage
+* Linode Object Storage
 * Minio (limited)
 * OpenStack Swift
 * S3Proxy


### PR DESCRIPTION
## Summary

I have not run any extensive test suites, but I've been using Linode Object Storage in a hobby project for some time and have yet to encounter an issue 😸 

I've also added a closed issue too detailing my experience configuring it, https://github.com/kahing/goofys/issues/665.

