### PR TITLE
Update Homebrew Cask Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ close-to-open.
 * On macOS, install via [Homebrew](https://brew.sh/):
 
 ```ShellSession
-$ brew cask install osxfuse
+$ brew install --cask osxfuse
 $ brew install goofys
 ```
 


### PR DESCRIPTION
Casks are now installed with `brew install --cask <name>` rather than `brew cask install <name>`.