### PR TITLE
Set subtype to goofys

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -29,6 +29,7 @@ func Mount(
 	// Mount the file system.
 	mountCfg := &fuse.MountConfig{
 		FSName:                  bucketName,
+		Subtype:                 "goofys",
 		Options:                 flags.MountOptions,
 		ErrorLogger:             GetStdLogger(NewLogger("fuse"), logrus.ErrorLevel),
 		DisableWritebackCaching: true,

--- a/internal/goofys_test.go
+++ b/internal/goofys_test.go
@@ -1632,6 +1632,7 @@ func (s *GoofysTest) mount(t *C, mountPoint string) {
 	// Mount the file system.
 	mountCfg := &fuse.MountConfig{
 		FSName:                  s.fs.bucket,
+		Subtype:                 "goofys",
 		Options:                 s.fs.flags.MountOptions,
 		ErrorLogger:             GetStdLogger(NewLogger("fuse"), logrus.ErrorLevel),
 		DisableWritebackCaching: true,


### PR DESCRIPTION
This allows identifying mounts as "fuse.goofys" instead of only
"fuse".