### PR TITLE
brew cask disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ close-to-open.
 * On macOS, install via [Homebrew](https://brew.sh/):
 
 ```ShellSession
-$ brew cask install osxfuse
+$ brew install --cask osxfuse
 $ brew install goofys
 ```
 


### PR DESCRIPTION
Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead.

- brew cask commands were deprecated on 2020-12-01 with the release of Homebrew 2.6.0. Starting then, all brew cask commands succeeded but displayed a warning informing users that the command would soon be disabled. The message also provides the appropriate replacement.
- brew cask commands were disabled on 2020-12-21 with the release of Homebrew 2.7.0. Starting then, all brew cask commands failed and displayed a warning informing users that the command is disabled. The message also provides the appropriate replacement.
- With the release of Homebrew 2.8.0 (release date TBD), this disable message will be removed.