### PR TITLE
Add goofys as user agent for s3 request

### DIFF
--- a/internal/backend_s3.go
+++ b/internal/backend_s3.go
@@ -126,7 +126,7 @@ func (s *S3Backend) newS3() {
 	s.S3.Handlers.Sign.PushBack(addAcceptEncoding)
 	s.S3.Handlers.Build.PushFrontNamed(request.NamedHandler{
 		Name: "UserAgentHandler",
-		Fn:   request.MakeAddToUserAgentHandler("Goofys", VersionNumber+"-"+VersionHash),
+		Fn:   request.MakeAddToUserAgentHandler("goofys", VersionNumber+"-"+VersionHash),
 	})
 }
 

--- a/internal/backend_s3.go
+++ b/internal/backend_s3.go
@@ -124,6 +124,10 @@ func (s *S3Backend) newS3() {
 		s.setV2Signer(&s.S3.Handlers)
 	}
 	s.S3.Handlers.Sign.PushBack(addAcceptEncoding)
+	s.S3.Handlers.Build.PushFrontNamed(request.NamedHandler{
+		Name: "UserAgentHandler",
+		Fn:   request.MakeAddToUserAgentHandler("Goofys", VersionNumber+"-"+VersionHash),
+	})
 }
 
 func (s *S3Backend) detectBucketLocationByHEAD() (err error, isAws bool) {

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -77,6 +77,7 @@ COPYRIGHT:
 `
 }
 
+var VersionNumber string
 var VersionHash string
 
 func NewApp() (app *cli.App) {
@@ -86,7 +87,7 @@ func NewApp() (app *cli.App) {
 
 	app = &cli.App{
 		Name:     "goofys",
-		Version:  "0.24.0-" + VersionHash,
+		Version:  VersionNumber + "-" + VersionHash,
 		Usage:    "Mount an S3 bucket locally",
 		HideHelp: true,
 		Writer:   os.Stderr,

--- a/main.go
+++ b/main.go
@@ -134,6 +134,7 @@ func massageArg0() {
 var Version = "use `make build' to fill version hash correctly"
 
 func main() {
+	VersionNumber = "0.24.0"
 	VersionHash = Version
 
 	massagePath()


### PR DESCRIPTION
This PR add "goofys/version-hash" to the user agent list for each request. You will be able to identify which requests come from goofys and which version if you enable [server access logging](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerLogs.html) or [CloudTrail](https://docs.aws.amazon.com/AmazonS3/latest/userguide/cloudtrail-logging-s3-info.html) on your buckets.

example for debug_s3 log

```
2022/05/18 10:08:32.838728 s3.DEBUG DEBUG: Request s3/ListObjectsV2 Details:
---[ REQUEST POST-SIGN ]-----------------------------
GET /<REDACTED>?delimiter=%2F&list-type=2&prefix= HTTP/1.1
Host: s3.eu-west-1.amazonaws.com
User-Agent: goofys/0.24.0-829d8e5ce20faa3f9f6f054077a14325e00e9249 aws-sdk-go/1.38.7 (go1.18.2; linux; amd64)
Accept-Encoding: identity
Authorization: AWS4-HMAC-SHA256 Credential=<REDACTED>, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=<REDACTED>
X-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
X-Amz-Date: 20220518T100832Z
```

example for server access log

```
fda01774e8671afabd99d08ccfcb4ef3a0fde3b84c04977a33cd49c863ac0b3e bucket-name [18/May/2022:10:07:30 +0000] <REDACTED> arn:aws:iam::<REDACTED>:user/<REDACTED> CVTB43X4F1MAXG2X REST.GET.OBJECT largefile "GET /bucket-name/largefile HTTP/1.1" 206 - 20971520 10240000000 685 128 "-" "goofys/0.24.0-829d8e5ce20faa3f9f6f054077a14325e00e9249 aws-sdk-go/1.38.7 (go1.18.2; linux; amd64)" - <REDACTED> SigV4 ECDHE-RSA-AES128-GCM-SHA256 AuthHeader s3.eu-west-1.amazonaws.com TLSv1.2 -
```
