### PR TITLE
Update instructions for new macOS guidance and drop source install for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,6 @@ $ brew cask install osxfuse
 $ brew install goofys
 ```
 
-* Or build from source with Go 1.10 or later:
-
-```ShellSession
-$ export GOPATH=$HOME/work
-$ go get github.com/kahing/goofys
-$ go install github.com/kahing/goofys
-```
-
 # Usage
 
 ```ShellSession

--- a/README.md
+++ b/README.md
@@ -18,14 +18,18 @@ close-to-open.
 
 # Installation
 
-* On Linux, install via [pre-built binaries](https://github.com/kahing/goofys/releases/latest/download/goofys). You may also need to install fuse-utils first.
+Ensure you have FUSE available on your system.
 
-* On macOS, install via [Homebrew](https://brew.sh/):
+* For Linux, you may need to install fuse-utils.
+* For macOS, you may need to install [macFUSE](https://osxfuse.github.io/) (prev. OSXFUSE).
+  This can be installed via the [macfuse Homebrew Cask](https://formulae.brew.sh/cask/macfuse).
 
-```ShellSession
-$ brew cask install osxfuse
-$ brew install goofys
-```
+You have the following options for installation.
+
+## Pre-built binaries
+
+You can [download pre-built goofys binaries](https://github.com/kahing/goofys/releases/latest/download/goofys) available on GitHub.
+Move these to a location in your PATH variable if you prefer to run without specifying a path to goofys.
 
 # Usage
 


### PR DESCRIPTION
In summary, this PR reworks the installation instructions in two ways.

Firstly, it drops the installation from source instructions, with the intention to add an updated version back once working. As #696 mentions, `go install` should be used instead of `go get` now. In terms of getting `go install` working, I'm seeing the same issues as #527, #664.

Secondly, it updates the instructions now that goofys is not available from Homebrew. This is due to a licensing change on the FUSE library used on macOS. Addresses #628.

Note, this does overlap with #618, #668, #687 but they do not address that goofys can no longer be installed via Homebrew (see Homebrew/homebrew-core#64491).

(closes #618, #668, #687)