### PR TITLE
Support writing files larger than 1TB

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,6 @@ List of non-POSIX behaviors/limitations:
   * `unlink` returns success even if file is not present
   * `fsync` is ignored, files are only flushed on `close`
 
-In addition to the items above, the following are supportable but not yet implemented:
-  * creating files larger than 1TB
-
 ## Compatibility with non-AWS S3
 
 goofys has been tested with the following non-AWS S3 providers:

--- a/internal/file.go
+++ b/internal/file.go
@@ -186,12 +186,14 @@ func (fh *FileHandle) waitForCreateMPU() (err error) {
 func (fh *FileHandle) partSize() uint64 {
 	var size uint64
 
-	if fh.lastPartId < 1000 {
+	if fh.lastPartId < 500 {
 		size = 5 * 1024 * 1024
-	} else if fh.lastPartId < 2000 {
+	} else if fh.lastPartId < 1000 {
 		size = 25 * 1024 * 1024
-	} else {
+	} else if fh.lastPartId < 2000 {
 		size = 125 * 1024 * 1024
+	} else {
+		size = 625 * 1024 * 1024
 	}
 
 	maxPartSize := fh.cloud.Capabilities().MaxMultipartSize


### PR DESCRIPTION
Increase max part size for multipart upload from 125MB to 625MB. As a result, we can write new files up to ~5TB from goofys. Related issue https://github.com/kahing/goofys/issues/686.

Tested manually by writing a file with size more than 1TB and running `make run-test` passed.