### PR TITLE
Fix potential memory consumption and OOMs by fixing logic in `getCgroupAvailableMem`

### DIFF
--- a/api/common/panic_logger.go
+++ b/api/common/panic_logger.go
@@ -27,6 +27,8 @@ type FusePanicLogger struct {
 	Fs fuseutil.FileSystem
 }
 
+var _ fuseutil.FileSystem = FusePanicLogger{}
+
 func LogPanic(err *error) {
 	if e := recover(); e != nil {
 		log.Errorf("stacktrace from panic: %v \n"+string(debug.Stack()), e)
@@ -34,6 +36,11 @@ func LogPanic(err *error) {
 			*err = fuse.EIO
 		}
 	}
+}
+
+func (fs FusePanicLogger) BatchForget(ctx context.Context, op *fuseops.BatchForgetOp) (err error) {
+	defer LogPanic(&err)
+	return fs.Fs.BatchForget(ctx, op)
 }
 
 func (fs FusePanicLogger) StatFS(ctx context.Context, op *fuseops.StatFSOp) (err error) {

--- a/api/common/panic_logger.go
+++ b/api/common/panic_logger.go
@@ -42,7 +42,6 @@ func (fs FusePanicLogger) BatchForget(ctx context.Context, op *fuseops.BatchForg
 	defer LogPanic(&err)
 	return fs.Fs.BatchForget(ctx, op)
 }
-
 func (fs FusePanicLogger) StatFS(ctx context.Context, op *fuseops.StatFSOp) (err error) {
 	defer LogPanic(&err)
 	return fs.Fs.StatFS(ctx, op)

--- a/internal/cgroup.go
+++ b/internal/cgroup.go
@@ -45,7 +45,7 @@ func getCgroupAvailableMem() (retVal uint64, err error) {
 
 	// newer version of docker mounts the cgroup memory limit/usage files directly under
 	// /sys/fs/cgroup/memory/ rather than /sys/fs/cgroup/memory/docker/$container_id/
-	if _, err := os.Stat(filepath.Join(CGROUP_FOLDER_PREFIX, path)); os.IsExist(err) {
+	if _, err := os.Stat(filepath.Join(CGROUP_FOLDER_PREFIX, path)); err == nil {
 		path = filepath.Join(CGROUP_FOLDER_PREFIX, path)
 	} else {
 		path = filepath.Join(CGROUP_FOLDER_PREFIX)


### PR DESCRIPTION
`os.Stat` is never returning `err` which satisfies `os.IsExist(err) == true`
the only way to make sure that file exists using `os.Stat` is to check `err == nil`

```
if _, err := os.Stat("/file/that/exists"); os.IsExist(err) {
  // will never trigger!

  // why? because os.Stat runs normally if file exists.
  // it's expected behaviour for os.Stat, so it doesn't throw an error

  // os.IsExist() does not receive an error ( it's nil ), so it can't tell you
  // if the error message was "file not found"
}
```

from https://pkg.go.dev/os#File.Stat
```
Stat returns the FileInfo structure describing file. If there is an error, it will be of type *PathError.
```

also I installed go mods from scratch and it required additional method for `FusePanicLogger` to satisfy `fuseutil.FileSystem`
I added the method