### PR TITLE
Remove duplicate definition of BatchForget function

### DIFF
--- a/api/common/panic_logger.go
+++ b/api/common/panic_logger.go
@@ -38,10 +38,6 @@ func LogPanic(err *error) {
 	}
 }
 
-func (fs FusePanicLogger) BatchForget(ctx context.Context, op *fuseops.BatchForgetOp) (err error) {
-	defer LogPanic(&err)
-	return fs.Fs.BatchForget(ctx, op)
-}
 func (fs FusePanicLogger) StatFS(ctx context.Context, op *fuseops.StatFSOp) (err error) {
 	defer LogPanic(&err)
 	return fs.Fs.StatFS(ctx, op)


### PR DESCRIPTION
This fixes build on both Linux & MacOS with Go 1.20