### PR TITLE
Signal parent once child takes over

### DIFF
--- a/main.go
+++ b/main.go
@@ -196,6 +196,9 @@ func main() {
 				kill(os.Getpid(), syscall.SIGUSR1)
 				wg.Wait()
 				defer ctx.Release()
+
+				// Signal parent process since we are taking over
+				_ = kill(os.Getppid(), syscall.SIGUSR1)
 			}
 
 		} else {
@@ -211,15 +214,9 @@ func main() {
 			flags)
 
 		if err != nil {
-			if !flags.Foreground {
-				kill(os.Getppid(), syscall.SIGUSR2)
-			}
 			log.Fatalf("Mounting file system: %v", err)
 			// fatal also terminates itself
 		} else {
-			if !flags.Foreground {
-				kill(os.Getppid(), syscall.SIGUSR1)
-			}
 			log.Println("File system has been successfully mounted.")
 			// Let the user unmount with Ctrl-C
 			// (SIGINT). But if cache is on, catfs will


### PR DESCRIPTION
Fix for: https://github.com/kahing/goofys/issues/230

Parent process was blocked waiting on `wg` sync.WaitGroup preventing autofs from managing the forked daemon child process. Sending the signal to parent once child is ready ensures parent process exits and lets child process handle mounting and serving FUSE requests.

Tested this in an EC2 instance with existing autofs (for NFS) with `goofys`:
```
$ cat /etc/auto.master
/mnt/data  /etc/auto.nfs
/mnt/data/s3  /etc/auto.s3

$ cat /etc/auto.s3
data -fstype=fuse,_netdev,allow_other,--region=us-west-2 :goofys#s3-bucket-name

# List contents of git repository in S3 bucket
$ ls /mnt/data/s3/data/repos/puntar/
HEAD  config  description  hooks  info  objects  packed-refs
```
