### PR TITLE
leak flags to avoid sleep and use SIGUSR3 instead of SIGUSR1

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 	"sync"
 	"syscall"
-	"time"
 
 	"context"
 
@@ -163,10 +162,6 @@ func main() {
 			err = fmt.Errorf("invalid arguments")
 			return
 		}
-		defer func() {
-			time.Sleep(time.Second)
-			flags.Cleanup()
-		}()
 
 		if !flags.Foreground {
 			var wg sync.WaitGroup


### PR DESCRIPTION
1. `time.Sleep(time.Second)` produces 1 second wait, remove it.
2. Fix for: #230: Use of `SIGUSR1` conflict with autofs/automount which cause autofs hang. Use SIGHUP resolved this issue.